### PR TITLE
Fix signing error when identity has more than one public key of one type

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dash Platform Extension",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "pshenmic",
   "homepage_url": "https://github.com/pshenmic/dash-platform-extension",
   "minimum_chrome_version": "119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-extension",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage": "https://github.com/pshenmic/dash-platform-extension",
   "description": "A browser extension wallet for interacting with Dash Platform, providing secure identity management, wallet functionality, and transaction signing capabilities for DApps.",
   "scripts": {

--- a/src/content-script/api/private/stateTransitions/approveStateTransition.ts
+++ b/src/content-script/api/private/stateTransitions/approveStateTransition.ts
@@ -1,12 +1,11 @@
 import { StateTransitionsRepository } from '../../../repository/StateTransitionsRepository'
 import { IdentitiesRepository } from '../../../repository/IdentitiesRepository'
-import { IdentityPublicKeyWASM, PrivateKeyWASM, StateTransitionWASM } from 'pshenmic-dpp'
+import { PrivateKeyWASM, StateTransitionWASM } from 'pshenmic-dpp'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { EventData } from '../../../../types/EventData'
 import { ApproveStateTransitionResponse } from '../../../../types/messages/response/ApproveStateTransitionResponse'
 import { ApproveStateTransitionPayload } from '../../../../types/messages/payloads/ApproveStateTransitionPayload'
 import { base64 } from '@scure/base'
-import { KeyPair } from '../../../../types/KeyPair'
 import { bytesToHex, hexToBytes, validateHex, validateIdentifier } from '../../../../utils'
 import { APIHandler } from '../../APIHandler'
 import { WalletRepository } from '../../../repository/WalletRepository'
@@ -59,7 +58,7 @@ export class ApproveStateTransitionHandler implements APIHandler {
     if (wallet.type === WalletType.keystore) {
       const keyPairs = await this.keyPairRepository.getAllByIdentity(payload.identity)
       const [keyPair] = keyPairs
-          .filter(keyPair => keyPair.identityPublicKey.securityLevel === 'HIGH' && keyPair.identityPublicKey.purpose === 'AUTHENTICATION')
+        .filter(keyPair => keyPair.identityPublicKey.securityLevel === 'HIGH' && keyPair.identityPublicKey.purpose === 'AUTHENTICATION')
 
       if (keyPair == null || keyPair.encryptedPrivateKey == null) {
         throw new Error(`Could not find HIGH / AUTHENTICATION private key for identity ${payload.identity}`)

--- a/src/content-script/repository/KeypairRepository.ts
+++ b/src/content-script/repository/KeypairRepository.ts
@@ -80,4 +80,28 @@ export class KeypairRepository {
 
     return null
   }
+
+  async getAllByIdentity (identifier: string): Promise<KeyPair[]> {
+    const network = await this.storageAdapter.get('network') as string
+    const walletId = await this.storageAdapter.get('currentWalletId') as string | null
+
+    if (walletId == null) {
+      throw new Error('Wallet is not chosen')
+    }
+
+    const storageKey = `keyPairs_${walletId}_${network}`
+
+    const keyPairsSchema = (await this.storageAdapter.get(storageKey) ?? {}) as KeyPairsSchema
+
+    const keyPairs = keyPairsSchema[identifier]
+
+    if (keyPairs == null || keyPairs.length === 0) {
+      return []
+    }
+
+    return keyPairs.map((keyPair) => ({
+      identityPublicKey: IdentityPublicKeyWASM.fromBase64(keyPair.identityPublicKey),
+      encryptedPrivateKey: keyPair.encryptedPrivateKey
+    }))
+  }
 }

--- a/src/types/PrivateAPIClient.ts
+++ b/src/types/PrivateAPIClient.ts
@@ -104,11 +104,10 @@ export class PrivateAPIClient {
     return response.identities
   }
 
-  async approveStateTransition (hash: string, identity: string, identityPublicKey: IdentityPublicKeyWASM, password: string): Promise<ApproveStateTransitionResponse> {
+  async approveStateTransition (hash: string, identity: string, password: string): Promise<ApproveStateTransitionResponse> {
     const payload: ApproveStateTransitionPayload = {
       hash,
       identity,
-      identityPublicKey: identityPublicKey.base64(),
       password
     }
 

--- a/src/types/PrivateAPIClient.ts
+++ b/src/types/PrivateAPIClient.ts
@@ -15,7 +15,6 @@ import { CreateIdentityPayload } from './messages/payloads/CreateIdentityPayload
 import { GetStateTransitionPayload } from './messages/payloads/GetStateTransitionPayload'
 import { CreateWalletResponse } from './messages/response/CreateWalletResponse'
 import { SwitchWalletPayload } from './messages/payloads/SwitchWalletPayload'
-import { IdentityPublicKeyWASM } from 'pshenmic-dpp'
 import { ApproveStateTransitionPayload } from './messages/payloads/ApproveStateTransitionPayload'
 import { ApproveStateTransitionResponse } from './messages/response/ApproveStateTransitionResponse'
 import { RejectStateTransitionResponse } from './messages/response/RejectStateTransitionResponse'

--- a/src/types/messages/payloads/ApproveStateTransitionPayload.ts
+++ b/src/types/messages/payloads/ApproveStateTransitionPayload.ts
@@ -1,6 +1,5 @@
 export interface ApproveStateTransitionPayload {
   hash: string
   identity: string
-  identityPublicKey: string
   password: string
 }

--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -241,20 +241,11 @@ function ApproveTransactionState (): React.JSX.Element {
         return
       }
 
-      const identity: IdentityWASM = await sdk.identities.getIdentityByIdentifier(currentIdentity)
-      const identityPublicKeys: IdentityPublicKeyWASM[] = identity.getPublicKeys()
-      const [identityPublicKey] = identityPublicKeys
-        .filter(publicKey => publicKey.purpose === 'AUTHENTICATION' && publicKey.securityLevel === 'HIGH')
-
-      if (identityPublicKey == null) {
-        throw new Error('no identity public key')
-      }
-
-      const response = await extensionAPI.approveStateTransition(stateTransitionWASM.hash(true), currentIdentity, identityPublicKey, password)
+      const response = await extensionAPI.approveStateTransition(stateTransitionWASM.hash(true), currentIdentity, password)
 
       setTxHash(response.txHash)
     } catch (error) {
-      console.error('Sign transition fails', error)
+      console.log('Signing transition failed', error)
       setPasswordError(`Signing failed: ${error.toString() as string}`)
     } finally {
       setIsSigningInProgress(false)

--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { base64 as base64Decoder } from '@scure/base'
-import { useSdk } from '../../hooks/useSdk'
 import TransactionDetails from './TransactionDetails'
 import ValueCard from '../../components/containers/ValueCard'
 import Identifier from '../../components/data/Identifier'
@@ -9,13 +8,12 @@ import Text from '../../text/Text'
 import Button from '../../components/controls/buttons'
 import { GetStateTransitionResponse } from '../../../types/messages/response/GetStateTransitionResponse'
 import { useExtensionAPI } from '../../hooks/useExtensionAPI'
-import { IdentityPublicKeyWASM, StateTransitionWASM, IdentityWASM } from 'pshenmic-dpp'
+import { StateTransitionWASM } from 'pshenmic-dpp'
 import { withAuthCheck } from '../../components/auth/withAuthCheck'
 import LoadingScreen from '../../components/layout/LoadingScreen'
 
 function ApproveTransactionState (): React.JSX.Element {
   const navigate = useNavigate()
-  const sdk = useSdk()
   const extensionAPI = useExtensionAPI()
 
   const params = useParams()


### PR DESCRIPTION
# Issue

There was a error, when user has many keys in the identity of one type (for example two of HIGH / AUTHENTICATION), the frontend was incorrectly choosing only the first one by default. That led to inability to sign the transaction, and the error `Signing error` were thrown

This PR moves logic of finding correct private / public keys into extension backend.

# Things done
* Moved out picking the right identity public key from frontend to API
* Bumped version