### PR TITLE
Add network to connectApp() response

### DIFF
--- a/src/content-script/api/PublicAPI.ts
+++ b/src/content-script/api/PublicAPI.ts
@@ -70,7 +70,7 @@ export class PublicAPI {
     this.walletRepository = walletRepository
 
     this.handlers = {
-      [MessagingMethods.CONNECT_APP]: new ConnectAppHandler(appConnectRepository, identitiesRepository, walletRepository),
+      [MessagingMethods.CONNECT_APP]: new ConnectAppHandler(appConnectRepository, identitiesRepository, walletRepository, this.storageAdapter),
       [MessagingMethods.REQUEST_STATE_TRANSITION_APPROVAL]: new RequestStateTransitionApprovalHandler(stateTransitionsRepository)
     }
 

--- a/src/content-script/api/public/connectApp.ts
+++ b/src/content-script/api/public/connectApp.ts
@@ -5,6 +5,7 @@ import { APIHandler } from '../APIHandler'
 import hash from 'hash.js'
 import { IdentitiesRepository } from '../../repository/IdentitiesRepository'
 import { WalletRepository } from '../../repository/WalletRepository'
+import { StorageAdapter } from '../../storage/storageAdapter'
 
 interface AppConnectRequestPayload {
   url: string
@@ -14,11 +15,13 @@ export class ConnectAppHandler implements APIHandler {
   appConnectRepository: AppConnectRepository
   identitiesRepository: IdentitiesRepository
   walletRepository: WalletRepository
+  storageAdapter: StorageAdapter
 
-  constructor (appConnectRepository: AppConnectRepository, identitiesRepository: IdentitiesRepository, walletRepository: WalletRepository) {
+  constructor (appConnectRepository: AppConnectRepository, identitiesRepository: IdentitiesRepository, walletRepository: WalletRepository, storageAdapter: StorageAdapter) {
     this.appConnectRepository = appConnectRepository
     this.identitiesRepository = identitiesRepository
     this.walletRepository = walletRepository
+    this.storageAdapter = storageAdapter
   }
 
   async handle (event: EventData): Promise<ConnectAppResponse> {
@@ -39,12 +42,14 @@ export class ConnectAppHandler implements APIHandler {
     }
 
     const identities = await this.identitiesRepository.getAll()
+    const network = await this.storageAdapter.get('network') as string
 
     return {
       redirectUrl: chrome.runtime.getURL(`index.html#/connect/${appConnect.id}`),
       status: appConnect.status,
       identities: identities.map(identity => ({ identifier: identity.identifier, type: identity.type, proTxHash: identity.proTxHash })),
-      currentIdentity: wallet.currentIdentity
+      currentIdentity: wallet.currentIdentity,
+      network
     }
   }
 

--- a/src/types/messages/response/ConnectAppResponse.ts
+++ b/src/types/messages/response/ConnectAppResponse.ts
@@ -5,4 +5,5 @@ export interface ConnectAppResponse {
   status: 'pending' | 'approved' | 'rejected' | 'error'
   identities: IdentityInfo[]
   currentIdentity: string | null
+  network: string
 }


### PR DESCRIPTION
## Summary

Adds `network` field to `connectApp()` response, allowing web applications to know which network the extension is currently using.

## Changes

- Added `network: string` to `ConnectAppResponse`
- `connectApp()` now returns current network (`testnet` | `mainnet`)

## Usage

```typescript
const { identities, currentIdentity, network } = await window.dashPlatformExtension.signer.connect()
// network => 'testnet' | 'mainnet'
```

## Motivation

Web applications need to detect network mismatches between the extension and their own SDK configuration.
