### PR TITLE
Activate private key screen

### DIFF
--- a/src/ui/components/settings/screens/PrivateKeysScreen.tsx
+++ b/src/ui/components/settings/screens/PrivateKeysScreen.tsx
@@ -622,7 +622,6 @@ export const PrivateKeysScreen: React.FC<SettingsScreenProps> = ({ currentIdenti
               onClick={handleCreateKey}
               colorScheme='lightBlue'
               className='flex-1'
-              disabled
             >
               Create New Key
             </Button>


### PR DESCRIPTION
# Issue
We disabled the creation of new keys because this functionality wasn't working on the platform. The platform has been updated, so now we need to activate it because it works.

# Things done
Removed `disable` props from " Create New Key" button