### PR TITLE
Fix Dash Usernames registration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           zipFilePath: release/dash-platform-extension_${{ github.event.release.tag_name }}_chrome.zip
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
           files: release/dash-platform-extension_${{ github.event.release.tag_name }}_chrome.zip
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           zipFilePath: release/dash-platform-extension_${{ github.event.release.tag_name }}_chrome.zip
 
       - name: Release
-        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
+        uses: softprops/action-gh-release@v2
         with:
           files: release/dash-platform-extension_${{ github.event.release.tag_name }}_chrome.zip
         env:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dash Platform Extension",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "pshenmic",
   "homepage_url": "https://github.com/pshenmic/dash-platform-extension",
   "minimum_chrome_version": "119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-platform-extension",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/pshenmic/dash-platform-extension",
   "description": "A browser extension wallet for interacting with Dash Platform, providing secure identity management, wallet functionality, and transaction signing capabilities for DApps.",
   "scripts": {
@@ -22,7 +22,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@scure/base": "^1.2.4",
     "@scure/bip39": "^1.6.0",
-    "dash-platform-sdk": "1.3.0-dev.14",
+    "dash-platform-sdk": "1.3.0-dev.15",
     "dash-ui-kit": "^1.0.93",
     "eciesjs": "^0.4.15",
     "hash.js": "^1.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,10 +3716,10 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-dash-platform-sdk@1.3.0-dev.14:
-  version "1.3.0-dev.14"
-  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.3.0-dev.14.tgz#439506de21e888b130fe910a77866c936001e970"
-  integrity sha512-ZIiR3YD8gjs+8FoCr3bXx5HNCFtfwaUZcItoSHqKT4vJoI9ooxDqESgWZ8aa5AKE7FFpy8cvZS6avRsOIX6N6Q==
+dash-platform-sdk@1.3.0-dev.15:
+  version "1.3.0-dev.15"
+  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.3.0-dev.15.tgz#f877be7720df576ac788dd0b364a5ca65f7557a8"
+  integrity sha512-0QK5B9zZuCis72nne8P6w/K7S4+JfqnFNOBB5OHNfnm4dHXV7tuciB9DAys3c406GJBTe+hmu2mM79yzMWRFpg==
   dependencies:
     "@bufbuild/protobuf" "^2.6.0"
     "@protobuf-ts/grpcweb-transport" "^2.11.1"


### PR DESCRIPTION
# Issue

Previous dash-platform-sdk version had an issue with waitForStateTransitionResult, which was leading to inability to register a DPNS name through the extension.

Mistake in SDK was fixed, and this PR updates the SDK which makes registration of Dash Usernames works again

# Things done

* Bumped dash-platform-sdk
* Bumped extension version 