### PR TITLE
Minor updates

### DIFF
--- a/src/enums/KeyLabels.ts
+++ b/src/enums/KeyLabels.ts
@@ -11,9 +11,9 @@ export const PurposeLabelsInfo = {
     label: 'Decryption',
     description: 'Key used for decryption purposes'
   },
-  MASTER: {
-    label: 'Master',
-    description: 'Master key with full privileges'
+  TRANSFER: {
+    label: 'Transfer',
+    description: 'Key used for transfers'
   }
 }
 

--- a/src/ui/components/settings/screens/CreateKeyScreen.tsx
+++ b/src/ui/components/settings/screens/CreateKeyScreen.tsx
@@ -5,7 +5,7 @@ import type { SettingsScreenProps, ScreenConfig } from '../types'
 import { WalletType } from '../../../../types'
 import { useExtensionAPI, useSdk, useSigningKeys } from '../../../hooks'
 import { KeyType } from 'dash-platform-sdk/types'
-import { InfoCard, OverlayMessage } from '../../common'
+import { InfoCard } from '../../common'
 import { TransactionSuccessScreen } from '../../layout/TransactionSuccessScreen'
 import { CreateIdentityPrivateKeyResponse } from '../../../../types/messages/response/CreateIdentityPrivateKeyResponse'
 import { hexToBytes } from '../../../../utils'
@@ -313,13 +313,6 @@ export const CreateKeyScreen: React.FC<SettingsScreenProps> = ({
         </Button>
       </div>
 
-      {/* Mainnet Unavailable Message  */}
-      {currentNetwork === 'mainnet' && (
-        <OverlayMessage
-          title='Mainnet Unavailable'
-          message='Mainnet private key generation is not yet available.'
-        />
-      )}
     </div>
   )
 }

--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -437,7 +437,7 @@ function ApproveTransactionState (): React.JSX.Element {
           : (stateTransitionWASM != null && (
             <ButtonRow
               leftButton={{
-                text: 'Reject',
+                text: 'Cancel',
                 onClick: reject,
                 colorScheme: 'lightBlue'
               }}

--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -443,7 +443,7 @@ function ApproveTransactionState (): React.JSX.Element {
               }}
               rightButton={{
                 text: isSigningInProgress ? 'Signing...' : 'Sign',
-                onClick: () => { doSign().catch(e => console.log('doSign', e)) },
+                onClick: () => { void doSign() },
                 colorScheme: 'brand',
                 disabled: isSigningInProgress || selectedSigningKey === null
               }}


### PR DESCRIPTION
# Issue
- The message "Mainnet private key generation is not yet available." needs to be removed on mainnet
- The extension does not display the "Transfer" value in the "Purpose" field for keys.

# Things done
- Massage "Mainnet private key generation is not yet available." removed
- Updated KeyLabels, to show "Transfer" value in the "Purpose" field
- Removed catch from doSign() call
