### PR TITLE
Change tx hex display to copy button on broadcast errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@scure/base": "^1.2.4",
     "@scure/bip39": "^1.6.0",
-    "dash-platform-sdk": "1.3.0-dev.15",
+    "dash-platform-sdk": "1.3.1",
     "dash-ui-kit": "2.1.0-dev",
     "eciesjs": "^0.4.15",
     "hash.js": "^1.1.7",

--- a/src/ui/components/errors/SigningErrorDetails.tsx
+++ b/src/ui/components/errors/SigningErrorDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Text, ValueCard, Identifier } from 'dash-ui-kit/react'
+import { Text, ValueCard } from 'dash-ui-kit/react'
 import { FieldLabel } from '../typography'
+import { CopyButton } from 'dash-ui-kit/react'
 
 export interface SigningErrorDetailsProps {
   name: string
@@ -14,16 +15,14 @@ export function SigningErrorDetails ({ name, message, hex }: SigningErrorDetails
       <div className='flex flex-col gap-2'>
         <FieldLabel>{name}</FieldLabel>
         <ValueCard colorScheme='yellow' size='xl' border={false} className='flex flex-col gap-2'>
-          <Text size='sm'>{message}</Text>
+          <Text size='sm' className='whitespace-pre-wrap break-words max-w-full'>{message}</Text>
         </ValueCard>
       </div>
       {hex != null && (
         <div className='flex flex-col gap-2'>
-          <FieldLabel>Transaction Hex</FieldLabel>
-          <ValueCard colorScheme='lightGray' size='xl' border={false} className='flex flex-col gap-2'>
-            <Identifier copyButton linesAdjustment={false}>
-              {hex}
-            </Identifier>
+          <ValueCard colorScheme='lightGray' size='xl' border={false} className='flex gap-2 justify-center'>
+            <Text size='sm' className='whitespace-pre-wrap break-words'>Copy Transaction Hex</Text>
+            <CopyButton text={hex} />
           </ValueCard>
         </div>
       )}

--- a/src/ui/components/errors/SigningErrorDetails.tsx
+++ b/src/ui/components/errors/SigningErrorDetails.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { Text, ValueCard } from 'dash-ui-kit/react'
+import { Text, ValueCard, CopyButton } from 'dash-ui-kit/react'
 import { FieldLabel } from '../typography'
-import { CopyButton } from 'dash-ui-kit/react'
 
 export interface SigningErrorDetailsProps {
   name: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3736,10 +3736,10 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-dash-platform-sdk@1.3.0-dev.15:
-  version "1.3.0-dev.15"
-  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.3.0-dev.15.tgz#f877be7720df576ac788dd0b364a5ca65f7557a8"
-  integrity sha512-0QK5B9zZuCis72nne8P6w/K7S4+JfqnFNOBB5OHNfnm4dHXV7tuciB9DAys3c406GJBTe+hmu2mM79yzMWRFpg==
+dash-platform-sdk@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.3.1.tgz#5e45b0e5e7635e5153def5b8d92cdf474387fdd8"
+  integrity sha512-tw03XKDGvyvsI7ey6CvDbvFb71MVqGcRnV83EFF8Fx8tl+azXUc/fjZQiK/aWNAe0a16/sphBKALzgIOl7Z70A==
   dependencies:
     "@bufbuild/protobuf" "^2.6.0"
     "@protobuf-ts/grpcweb-transport" "^2.11.1"


### PR DESCRIPTION
# Issue
When a hex is displayed in an error block, it is not convenient. The copy button is enough

# Things done 
- Removed display of full hex in error block
- Added line breaks to error message