### PR TITLE
Fix blank error message on sign

### DIFF
--- a/src/content-script/api/private/stateTransitions/approveStateTransition.ts
+++ b/src/content-script/api/private/stateTransitions/approveStateTransition.ts
@@ -102,7 +102,7 @@ export class ApproveStateTransitionHandler implements APIHandler {
       throw new Error(`Could not find Identity Public Key with Key ID ${keyId} in Identity ${identity.identifier}`)
     }
 
-    stateTransitionWASM.sign(privateKeyWASM, identityPublicKey)
+    stateTransitionWASM.sign('asdsad', identityPublicKey)
 
     return stateTransitionWASM
   }
@@ -133,7 +133,7 @@ export class ApproveStateTransitionHandler implements APIHandler {
     try {
       stateTransitionWASM = await this.sign(stateTransition.unsigned, wallet, identity, payload.keyId, payload.password)
     } catch (e) {
-      throw new SigningError(e.message)
+      throw new SigningError(e.message ?? e)
     }
 
     const ownerId = stateTransitionWASM.getOwnerId()
@@ -172,7 +172,7 @@ export class ApproveStateTransitionHandler implements APIHandler {
       console.log('Failed to broadcast transaction', e)
       await this.stateTransitionsRepository.update(stateTransitionWASM, StateTransitionStatus.error, e.message)
 
-      throw new BroadcastError(e.message, signedHex)
+      throw new BroadcastError(e.message ?? e, signedHex)
     }
 
     return {

--- a/src/content-script/api/private/stateTransitions/approveStateTransition.ts
+++ b/src/content-script/api/private/stateTransitions/approveStateTransition.ts
@@ -102,7 +102,7 @@ export class ApproveStateTransitionHandler implements APIHandler {
       throw new Error(`Could not find Identity Public Key with Key ID ${keyId} in Identity ${identity.identifier}`)
     }
 
-    stateTransitionWASM.sign('asdsad', identityPublicKey)
+    stateTransitionWASM.sign(privateKeyWASM, identityPublicKey)
 
     return stateTransitionWASM
   }


### PR DESCRIPTION
# Issue

DPP returns a error as string, but signing try-catch handler was expecting an e.message field as an error message, which resulted to undefined to be passed as error string. That caused blank error message on approve transaction screen.

# Things done

* Added fallback for errors using ?? in broadcast and sign try catch handlers