### PR TITLE
Fix security level on approve transactions state

### DIFF
--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -162,7 +162,7 @@ function ApproveTransactionState (): React.JSX.Element {
       const purposeRequirements = stateTransitionWASM.getPurposeRequirement()
       const requirements: KeyRequirement[] = []
 
-      const hasTokenTransfer = Array.isArray(decodedTransaction?.transitions) &&
+      const hasTokenTransfer: boolean = Array.isArray(decodedTransaction?.transitions) &&
         decodedTransaction.transitions.some((t: any) => t.action === 'TOKEN_TRANSFER')
 
       if (Array.isArray(purposeRequirements)) {

--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -162,6 +162,9 @@ function ApproveTransactionState (): React.JSX.Element {
       const purposeRequirements = stateTransitionWASM.getPurposeRequirement()
       const requirements: KeyRequirement[] = []
 
+      const hasTokenTransfer = Array.isArray(decodedTransaction?.transitions) &&
+        decodedTransaction.transitions.some((t: any) => t.action === 'TOKEN_TRANSFER')
+
       if (Array.isArray(purposeRequirements)) {
         for (const purpose of purposeRequirements) {
           const securityLevel = stateTransitionWASM.getKeyLevelRequirement(purpose)
@@ -170,7 +173,7 @@ function ApproveTransactionState (): React.JSX.Element {
             securityLevel.forEach(level => {
               requirements.push({
                 purpose,
-                securityLevel: level
+                securityLevel: hasTokenTransfer ? 'CRITICAL' : level
               })
             })
           }
@@ -182,7 +185,7 @@ function ApproveTransactionState (): React.JSX.Element {
       console.log('Error extracting key requirements:', error)
       setKeyRequirements([])
     }
-  }, [stateTransitionWASM])
+  }, [stateTransitionWASM, decodedTransaction])
 
   if (isCheckingWallet || isLoadingIdentities) {
     return (


### PR DESCRIPTION
# Issue
The DPP returns an incorrect value for the available securityLevel for signing token transfers transactions. 

# Things done
A securityLevel exception has been added for token transfers. Now, only "CRITICAL" security level are available for signing token transfers  transactions.