### PR TITLE
fix(identity): add robust instantLock/chainLock handling in registration flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@scure/base": "^1.2.4",
     "@scure/bip39": "^1.6.0",
     "dash-core-sdk": "https://github.com/pshenmic/dash-core-sdk#cd541b0f788b66d32be3697a8e4dd155ae7f6ca6",
-    "dash-platform-sdk": "1.3.1",
+    "dash-platform-sdk": "1.3.2-dev.3",
     "dash-ui-kit": "2.1.0-dev",
     "eciesjs": "^0.4.15",
     "hash.js": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@scure/base": "^1.2.4",
     "@scure/bip39": "^1.6.0",
-    "dash-core-sdk": "https://github.com/pshenmic/dash-core-sdk#cd541b0f788b66d32be3697a8e4dd155ae7f6ca6",
+    "dash-core-sdk": "https://github.com/pshenmic/dash-core-sdk#4e536a88a76deccae1a987ad965b0a8b5991de86",
     "dash-platform-sdk": "1.3.2-dev.3",
     "dash-ui-kit": "2.1.0-dev",
     "eciesjs": "^0.4.15",

--- a/src/content-script/api/PrivateAPI.ts
+++ b/src/content-script/api/PrivateAPI.ts
@@ -86,7 +86,7 @@ export class PrivateAPI {
     const keypairRepository = new KeypairRepository(this.storageAdapter, this.sdk)
     const stateTransitionsRepository = new StateTransitionsRepository(this.storageAdapter)
     const appConnectRepository = new AppConnectRepository(this.storageAdapter)
-    const oneTimeAddressesRepository = new OneTimeAddressesRepository(this.storageAdapter, this.sdk)
+    const oneTimeAddressesRepository = new OneTimeAddressesRepository(this.storageAdapter, this.sdk, walletRepository)
 
     this.handlers = {
       [MessagingMethods.GET_STATUS]: new GetStatusHandler(this.storageAdapter),

--- a/src/content-script/api/private/assetLocks/requestOneTimeAddress.ts
+++ b/src/content-script/api/private/assetLocks/requestOneTimeAddress.ts
@@ -2,6 +2,7 @@ import { EventData } from '../../../../types'
 import { APIHandler } from '../../APIHandler'
 import { OneTimeAddressesRepository } from '../../../repository/OneTimeAddressesRepository'
 import { RequestOneTimeAddressResponse } from '../../../../types/messages/response/RequestOneTimeAddressResponse'
+import { RequestOneTimeAddressPayload } from '../../../../types/messages/payloads/RequestOneTimeAddressPayload'
 
 export class RequestOneTimeAddressHandler implements APIHandler {
   oneTimeAddressesRepository: OneTimeAddressesRepository
@@ -10,13 +11,18 @@ export class RequestOneTimeAddressHandler implements APIHandler {
     this.oneTimeAddressesRepository = oneTimeAddressesRepository
   }
 
-  async handle (_event: EventData): Promise<RequestOneTimeAddressResponse> {
-    const { address } = await this.oneTimeAddressesRepository.create()
+  async handle (event: EventData): Promise<RequestOneTimeAddressResponse> {
+    const payload = (event.payload ?? {}) as RequestOneTimeAddressPayload
+    const { address } = await this.oneTimeAddressesRepository.create(payload.password)
 
     return { address }
   }
 
-  validatePayload (_payload: any): null | string {
+  validatePayload (payload: RequestOneTimeAddressPayload): null | string {
+    if (payload?.password != null && typeof payload.password !== 'string') {
+      return 'password must be a string'
+    }
+
     return null
   }
 }

--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -16,6 +16,7 @@ import {
   buildAssetLockFromPaymentTx,
   waitForAssetLockProof
 } from '../../../services/identityRegistration'
+import { wait } from '../../../../utils'
 
 export class RegisterIdentityHandler implements APIHandler {
   walletRepository: WalletRepository
@@ -76,6 +77,7 @@ export class RegisterIdentityHandler implements APIHandler {
     const oneTimePrivateKeyWif: string = oneTimePrivateKeyWASM.WIF()
 
     // ── 3. Build asset lock transaction from the payment tx ──────────────────
+    console.log('[registerIdentity] step 3: building asset lock tx...')
     const { assetLockTx } = await buildAssetLockFromPaymentTx({
       coreSDK: this.coreSDK,
       network,
@@ -84,6 +86,7 @@ export class RegisterIdentityHandler implements APIHandler {
       oneTimePrivateKeyWif,
       outputIndex: payload.outputIndex
     })
+    console.log('[registerIdentity] step 3: done')
 
     // ── 4. Broadcast the asset lock transaction ──────────────────────────────
     const broadcastResult = await this.coreSDK.broadcastTransaction(assetLockTx.bytes())
@@ -117,7 +120,7 @@ export class RegisterIdentityHandler implements APIHandler {
       securityLevel: SecurityLevel.MASTER,
       keyType: KeyType.ECDSA_SECP256K1,
       readOnly: false,
-      data: identityPrivateKey.getPublicKey().bytes(),
+      data: Uint8Array.from(identityPrivateKey.getPublicKey().bytes()),
       signature: undefined as Uint8Array | undefined
     }
 
@@ -130,7 +133,12 @@ export class RegisterIdentityHandler implements APIHandler {
     })
 
     stateTransition.signByPrivateKey(identityPrivateKey, undefined, KeyType.ECDSA_SECP256K1)
-    identityPublicKeyInCreation.signature = stateTransition.signature
+    // Force-copy out of WASM memory — the step-7 state transition will be GC'd
+    // after reassignment in step 8, invalidating any WASM-backed Uint8Array it owns.
+    if (stateTransition.signature == null) {
+      throw new Error('signByPrivateKey did not produce a signature for the identity key')
+    }
+    identityPublicKeyInCreation.signature = Uint8Array.from(stateTransition.signature)
 
     // ── 8. Finalize: re-create with signed keys, sign with asset lock key ────
     stateTransition = this.sdk.identities.createStateTransition('create', {
@@ -140,6 +148,8 @@ export class RegisterIdentityHandler implements APIHandler {
 
     stateTransition.signByPrivateKey(oneTimePrivateKeyWASM, undefined, KeyType.ECDSA_SECP256K1)
 
+    console.log('1: ======>', stateTransition.hex())
+
     // ── 9. Derive the new identity identifier ────────────────────────────────
     const identifier = stateTransition.getOwnerId()?.base58()
 
@@ -147,13 +157,44 @@ export class RegisterIdentityHandler implements APIHandler {
       throw new Error('Could not derive identity identifier from state transition')
     }
 
-    // hash(skip_signature: boolean): string — returns a hex string directly
-    const stateTransitionHash: string = stateTransition.hash(false)
-
     console.log('[registerIdentity] Identity identifier:', identifier)
 
-    // ── 10. Broadcast the state transition ───────────────────────────────────
-    await this.sdk.stateTransitions.broadcast(stateTransition)
+    // ── 10. Broadcast the state transition (with retry for chain height race) ──
+    // Chain lock proofs can arrive 1 block ahead of the platform's consensus height.
+    // Recreate the state transition on each attempt: WASM objects can become stale
+    // after a failed broadcast call.
+    const MAX_BROADCAST_RETRIES = 5
+    const BROADCAST_RETRY_DELAY_MS = 15_000
+    for (let attempt = 0; ; attempt++) {
+      // Recreate and re-sign on every attempt (including first) to get a fresh WASM object.
+      console.log(`[registerIdentity] broadcast attempt ${attempt}: creating state transition...`)
+      // stateTransition = this.sdk.identities.createStateTransition('create', {
+      //   publicKeys: [identityPublicKeyInCreation],
+      //   assetLockProof
+      // })
+      // console.log(`[registerIdentity] broadcast attempt ${attempt}: signing...`)
+      // stateTransition.signByPrivateKey(oneTimePrivateKeyWASM, undefined, KeyType.ECDSA_SECP256K1)
+      console.log(`[registerIdentity] broadcast attempt ${attempt}: broadcasting...`)
+      console.log('2: ======>', stateTransition.hex())
+
+      try {
+        await this.sdk.stateTransitions.broadcast(stateTransition)
+        console.log(`[registerIdentity] broadcast attempt ${attempt}: success`)
+        break
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        console.log(`[registerIdentity] broadcast attempt ${attempt}: failed — ${msg}`)
+        if (attempt < MAX_BROADCAST_RETRIES && msg.includes('core chain height')) {
+          console.log(`[registerIdentity] Chain height race, retrying in ${BROADCAST_RETRY_DELAY_MS / 1000}s (attempt ${attempt + 1}/${MAX_BROADCAST_RETRIES})`)
+          await wait(BROADCAST_RETRY_DELAY_MS)
+        } else {
+          throw e
+        }
+      }
+    }
+
+    // hash(skip_signature: boolean): string — computed after successful broadcast
+    const stateTransitionHash: string = stateTransition.hash(false)
 
     // ── 11. Wait for confirmation ────────────────────────────────────────────
     await this.sdk.stateTransitions.waitForStateTransitionResult(stateTransition)

--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -105,6 +105,7 @@ export class RegisterIdentityHandler implements APIHandler {
     // ── 5. Wait for instant lock or chain lock (whichever comes first) ──────
     const assetLockProof = await waitForAssetLockProof(
       this.coreSDK,
+      this.sdk,
       assetLockTx,
       assetLockTxid,
       payload.paymentAddress,
@@ -115,8 +116,6 @@ export class RegisterIdentityHandler implements APIHandler {
 
     console.log('[registerIdentity] Asset lock proof type:', assetLockProof.type)
 
-    console.log('[registerIdentity] Waiting 500ms')
-    await wait(500)
 
     // ── 6. Build the master identity key pair ────────────────────────────────
     const identityPrivateKey = PrivateKeyWASM.fromHex(

--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -1,5 +1,5 @@
 import { DashCoreSDK } from 'dash-core-sdk'
-import { KeyType, PrivateKeyWASM, Purpose, SecurityLevel } from 'dash-platform-sdk/types'
+import { KeyType, Network, PrivateKeyWASM, Purpose, SecurityLevel } from 'dash-platform-sdk/types'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { EventData } from '../../../../types'
 import { APIHandler } from '../../APIHandler'
@@ -16,7 +16,14 @@ import {
   buildAssetLockFromPaymentTx,
   waitForAssetLockProof
 } from '../../../services/identityRegistration'
-import {hexToBytes, wait} from '../../../../utils'
+import {
+  deriveSeedphrasePrivateKey,
+  deriveSeedphraseRegistrationFundingPrivateKey,
+  getNextIdentityIndex,
+  hexToBytes,
+  wait
+} from '../../../../utils'
+import { WalletType } from '../../../../types/WalletType'
 
 export class RegisterIdentityHandler implements APIHandler {
   walletRepository: WalletRepository
@@ -68,16 +75,61 @@ export class RegisterIdentityHandler implements APIHandler {
       )
     }
 
-    const oneTimePrivateKeyWASM: PrivateKeyWASM = decryptOneTimePrivateKey(
-      oneTimeAddressEntry.encryptedPrivateKey,
-      payload.password,
-      network
-    )
+    const oneTimeIdentityIndex = Number.isSafeInteger(oneTimeAddressEntry.identityIndex) &&
+      oneTimeAddressEntry.identityIndex >= 0
+      ? oneTimeAddressEntry.identityIndex
+      : null
+
+    let oneTimePrivateKeyWASM: PrivateKeyWASM
+    let identityIndex: number
+
+    if (wallet.type === WalletType.seedphrase) {
+      if (oneTimeIdentityIndex == null) {
+        throw new Error(
+          `One-time address ${payload.paymentAddress} has no identityIndex. ` +
+          'Seedphrase wallet registration requires a deterministic one-time address tied to an identity index.'
+        )
+      }
+
+      identityIndex = oneTimeIdentityIndex
+
+      oneTimePrivateKeyWASM = await deriveSeedphraseRegistrationFundingPrivateKey(
+        wallet,
+        payload.password,
+        identityIndex,
+        this.sdk
+      )
+
+      const derivedAddress = this.sdk.keyPair.p2pkhAddress(
+        oneTimePrivateKeyWASM.getPublicKey().bytes(),
+        network as Network
+      )
+
+      if (derivedAddress !== payload.paymentAddress) {
+        throw new Error(
+          `Stored one-time address ${payload.paymentAddress} does not match derived ` +
+          `registration funding address for identity index ${identityIndex}`
+        )
+      }
+    } else {
+      if (oneTimeAddressEntry.encryptedPrivateKey == null || oneTimeAddressEntry.encryptedPrivateKey === '') {
+        throw new Error('Missing encryptedPrivateKey for keystore registration flow')
+      }
+
+      identityIndex = oneTimeIdentityIndex ?? getNextIdentityIndex(
+        (await this.identitiesRepository.getAll()).map((identity) => identity.index)
+      )
+
+      oneTimePrivateKeyWASM = decryptOneTimePrivateKey(
+        oneTimeAddressEntry.encryptedPrivateKey,
+        payload.password,
+        network
+      )
+    }
 
     const oneTimePrivateKeyWif: string = oneTimePrivateKeyWASM.WIF()
 
     // ── 3. Build asset lock transaction from the payment tx ──────────────────
-    console.log('[registerIdentity] step 3: building asset lock tx...')
     const { assetLockTx } = await buildAssetLockFromPaymentTx({
       coreSDK: this.coreSDK,
       network,
@@ -86,7 +138,6 @@ export class RegisterIdentityHandler implements APIHandler {
       oneTimePrivateKeyWif,
       outputIndex: payload.outputIndex
     })
-    console.log('[registerIdentity] step 3: done')
 
     // ── 4. Broadcast the asset lock transaction ──────────────────────────────
     // Open the instant lock subscription before broadcasting so we don't miss
@@ -97,10 +148,7 @@ export class RegisterIdentityHandler implements APIHandler {
       [hexToBytes(assetLockTxid)]
     )
 
-    const broadcastResult = await this.coreSDK.broadcastTransaction(assetLockTx.bytes())
-
-    console.log('[registerIdentity] Asset lock broadcast result:', broadcastResult)
-    console.log('[registerIdentity] Asset lock txid:', assetLockTxid)
+    await this.coreSDK.broadcastTransaction(assetLockTx.bytes())
 
     // ── 5. Wait for instant lock or chain lock (whichever comes first) ──────
     const assetLockProof = await waitForAssetLockProof(
@@ -114,17 +162,14 @@ export class RegisterIdentityHandler implements APIHandler {
       instantLockSub
     )
 
-    console.log('[registerIdentity] Asset lock proof type:', assetLockProof.type)
-
-
     // ── 6. Build the master identity key pair ────────────────────────────────
-    const identityPrivateKey = PrivateKeyWASM.fromHex(
-      // Generate a random key for the identity master key (keystore wallet model).
-      // For seedphrase wallets this would be derived — here we generate a random key
-      // and save it encrypted; users can re-derive later via the export flow.
-      generateSecureHex(32),
-      network
-    )
+    const identityPrivateKey = wallet.type === WalletType.seedphrase
+      ? await deriveSeedphrasePrivateKey(wallet, payload.password, identityIndex, 0, this.sdk)
+      : PrivateKeyWASM.fromHex(
+        // Generate a random master key for keystore wallets.
+        generateSecureHex(32),
+        network
+      )
 
     const identityPublicKeyInCreation = {
       id: 0,
@@ -160,8 +205,6 @@ export class RegisterIdentityHandler implements APIHandler {
 
     stateTransition.signByPrivateKey(oneTimePrivateKeyWASM, undefined, KeyType.ECDSA_SECP256K1)
 
-    console.log('1: ======>', stateTransition.hex())
-
     // ── 9. Derive the new identity identifier ────────────────────────────────
     const identifier = stateTransition.getOwnerId()?.base58()
 
@@ -169,36 +212,17 @@ export class RegisterIdentityHandler implements APIHandler {
       throw new Error('Could not derive identity identifier from state transition')
     }
 
-    console.log('[registerIdentity] Identity identifier:', identifier)
-
     // ── 10. Broadcast the state transition (with retry for chain height race) ──
     // Chain lock proofs can arrive 1 block ahead of the platform's consensus height.
-    // Recreate the state transition on each attempt: WASM objects can become stale
-    // after a failed broadcast call.
     const MAX_BROADCAST_RETRIES = 5
     const BROADCAST_RETRY_DELAY_MS = 15_000
     for (let attempt = 0; ; attempt++) {
-      // Recreate and re-sign on every attempt (including first) to get a fresh WASM object.
-      console.log(`[registerIdentity] broadcast attempt ${attempt}: creating state transition...`)
-      // stateTransition = this.sdk.identities.createStateTransition('create', {
-      //   publicKeys: [identityPublicKeyInCreation],
-      //   assetLockProof
-      // })
-      // console.log(`[registerIdentity] broadcast attempt ${attempt}: signing...`)
-      // stateTransition.signByPrivateKey(oneTimePrivateKeyWASM, undefined, KeyType.ECDSA_SECP256K1)
-      console.log(`[registerIdentity] broadcast attempt ${attempt}: broadcasting...`)
-      console.log('2: ======>', stateTransition.hex())
-
       try {
         await this.sdk.stateTransitions.broadcast(stateTransition)
-        console.log(`[registerIdentity] broadcast attempt ${attempt}: success`)
         break
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
-        console.error(e)
-        console.log(`[registerIdentity] broadcast attempt ${attempt}: failed — ${msg}`)
         if (attempt < MAX_BROADCAST_RETRIES && msg.includes('core chain height')) {
-          console.log(`[registerIdentity] Chain height race, retrying in ${BROADCAST_RETRY_DELAY_MS / 1000}s (attempt ${attempt + 1}/${MAX_BROADCAST_RETRIES})`)
           await wait(BROADCAST_RETRY_DELAY_MS)
         } else {
           throw e
@@ -213,12 +237,15 @@ export class RegisterIdentityHandler implements APIHandler {
     await this.sdk.stateTransitions.waitForStateTransitionResult(stateTransition)
 
     // ── 12. Persist identity and keys ────────────────────────────────────────
-    await this.identitiesRepository.create(identifier, IdentityType.regular)
+    await this.identitiesRepository.create(identifier, IdentityType.regular, undefined, identityIndex)
 
-    // Save the identity master key (keyId 0) using addVerified to skip remote validation.
-    // The identity is confirmed on-chain at this point, but we generated the key
-    // randomly so we save it directly without another round-trip.
-    await this.keypairRepository.addVerified(identifier, identityPrivateKey.hex(), 0)
+    // Keystore wallets persist generated private keys in extension storage.
+    // Seedphrase wallets derive keys from the mnemonic and don't store key material.
+    if (wallet.type === WalletType.keystore) {
+      await this.keypairRepository.addVerified(identifier, identityPrivateKey.hex(), 0)
+    }
+
+    await this.oneTimeAddressesRepository.removeByAddress(payload.paymentAddress)
 
     // ── 13. Switch to the new identity ───────────────────────────────────────
     await this.walletRepository.switchIdentity(identifier)
@@ -249,6 +276,7 @@ export class RegisterIdentityHandler implements APIHandler {
 
     return null
   }
+
 }
 
 /** Generates cryptographically random hex of the given byte length. */

--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -16,7 +16,7 @@ import {
   buildAssetLockFromPaymentTx,
   waitForAssetLockProof
 } from '../../../services/identityRegistration'
-import { wait } from '../../../../utils'
+import {hexToBytes, wait} from '../../../../utils'
 
 export class RegisterIdentityHandler implements APIHandler {
   walletRepository: WalletRepository
@@ -89,8 +89,15 @@ export class RegisterIdentityHandler implements APIHandler {
     console.log('[registerIdentity] step 3: done')
 
     // ── 4. Broadcast the asset lock transaction ──────────────────────────────
-    const broadcastResult = await this.coreSDK.broadcastTransaction(assetLockTx.bytes())
+    // Open the instant lock subscription before broadcasting so we don't miss
+    // an instant lock that arrives before the subscription is established.
     const assetLockTxid = assetLockTx.hash()
+    const instantLockSub = this.coreSDK.subscribeToTransactions(
+      [payload.paymentAddress],
+      [hexToBytes(assetLockTxid)]
+    )
+
+    const broadcastResult = await this.coreSDK.broadcastTransaction(assetLockTx.bytes())
 
     console.log('[registerIdentity] Asset lock broadcast result:', broadcastResult)
     console.log('[registerIdentity] Asset lock txid:', assetLockTxid)
@@ -100,10 +107,16 @@ export class RegisterIdentityHandler implements APIHandler {
       this.coreSDK,
       assetLockTx,
       assetLockTxid,
-      payload.paymentAddress
+      payload.paymentAddress,
+      undefined,
+      undefined,
+      instantLockSub
     )
 
     console.log('[registerIdentity] Asset lock proof type:', assetLockProof.type)
+
+    console.log('[registerIdentity] Waiting 500ms')
+    await wait(500)
 
     // ── 6. Build the master identity key pair ────────────────────────────────
     const identityPrivateKey = PrivateKeyWASM.fromHex(
@@ -183,6 +196,7 @@ export class RegisterIdentityHandler implements APIHandler {
         break
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
+        console.error(e)
         console.log(`[registerIdentity] broadcast attempt ${attempt}: failed — ${msg}`)
         if (attempt < MAX_BROADCAST_RETRIES && msg.includes('core chain height')) {
           console.log(`[registerIdentity] Chain height race, retrying in ${BROADCAST_RETRY_DELAY_MS / 1000}s (attempt ${attempt + 1}/${MAX_BROADCAST_RETRIES})`)

--- a/src/content-script/repository/IdentitiesRepository.ts
+++ b/src/content-script/repository/IdentitiesRepository.ts
@@ -3,6 +3,7 @@ import { Identity } from '../../types'
 import { IdentitiesStoreSchema, IdentityStoreSchema } from '../storage/storageSchema'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { IdentityType } from '../../types/enums/IdentityType'
+import { getNextIdentityIndex } from '../../utils'
 
 export class IdentitiesRepository {
   storageAdapter: StorageAdapter
@@ -13,7 +14,7 @@ export class IdentitiesRepository {
     this.storageAdapter = storageAdapter
   }
 
-  async create (identifier: string, type: IdentityType, proTxHash?: string): Promise<Identity> {
+  async create (identifier: string, type: IdentityType, proTxHash?: string, explicitIndex?: number): Promise<Identity> {
     const network = await this.storageAdapter.get('network') as string
     const walletId = await this.storageAdapter.get('currentWalletId') as string | null
 
@@ -29,9 +30,19 @@ export class IdentitiesRepository {
       throw new Error(`Identity with identifier ${identifier} already exists`)
     }
 
-    const index = Object.entries(identities)
-      .map(([, entry]) => (entry.index))
-      .reduce((acc, index) => Math.max(acc, index + 1), 0)
+    const index = explicitIndex ?? getNextIdentityIndex(
+      Object.values(identities).map((entry) => entry.index)
+    )
+
+    if (!Number.isSafeInteger(index) || index < 0) {
+      throw new Error(`Identity index must be a non-negative integer: ${index}`)
+    }
+
+    const indexInUse = Object.values(identities).some((entry) => entry.index === index)
+
+    if (indexInUse) {
+      throw new Error(`Identity index ${index} is already used`)
+    }
 
     const identityStoreSchema: IdentityStoreSchema = {
       index,

--- a/src/content-script/repository/OneTimeAddressesRepository.ts
+++ b/src/content-script/repository/OneTimeAddressesRepository.ts
@@ -1,21 +1,24 @@
 import { StorageAdapter } from '../storage/storageAdapter'
-import { OneTimeAddressSchema, OneTimeAddressesSchema } from '../storage/storageSchema'
+import { IdentitiesStoreSchema, OneTimeAddressSchema, OneTimeAddressesSchema } from '../storage/storageSchema'
 import { encrypt } from 'eciesjs'
-import { bytesToHex, hexToBytes } from '../../utils'
+import { bytesToHex, deriveSeedphraseRegistrationFundingPrivateKey, getNextIdentityIndex, hexToBytes } from '../../utils'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { Network, PrivateKeyWASM } from 'dash-platform-sdk/types'
-import { generateRandomHex } from '../../utils'
+import { WalletRepository } from './WalletRepository'
+import { WalletType } from '../../types/WalletType'
 
 export class OneTimeAddressesRepository {
   storageAdapter: StorageAdapter
   sdk: DashPlatformSDK
+  walletRepository: WalletRepository
 
-  constructor (storageAdapter: StorageAdapter, sdk: DashPlatformSDK) {
+  constructor (storageAdapter: StorageAdapter, sdk: DashPlatformSDK, walletRepository: WalletRepository) {
     this.storageAdapter = storageAdapter
     this.sdk = sdk
+    this.walletRepository = walletRepository
   }
 
-  async create (): Promise<OneTimeAddressSchema> {
+  async create (password?: string): Promise<OneTimeAddressSchema> {
     const network = await this.storageAdapter.get('network') as string
     const walletId = await this.storageAdapter.get('currentWalletId') as string | null
 
@@ -29,15 +32,52 @@ export class OneTimeAddressesRepository {
       throw new Error('Password is not set for an extension')
     }
 
-    const privateKeyWASM = PrivateKeyWASM.fromHex(generateRandomHex(64), network)
-    const address = this.sdk.keyPair.p2pkhAddress(privateKeyWASM.getPublicKey().bytes(), network as Network)
-    const encryptedPrivateKey = bytesToHex(encrypt(passwordPublicKey, hexToBytes(privateKeyWASM.hex())))
-
     const storageKey = `oneTimeAddresses_${network}_${walletId}`
 
     const oneTimeAddresses = (await this.storageAdapter.get(storageKey) ?? {}) as OneTimeAddressesSchema
+    const identitiesStorageKey = `identities_${network}_${walletId}`
+    const identities = (await this.storageAdapter.get(identitiesStorageKey) ?? {}) as IdentitiesStoreSchema
+    const nextIdentityIndex = getNextIdentityIndex(Object.values(identities).map((identity) => identity.index))
 
-    const entry: OneTimeAddressSchema = { address, encryptedPrivateKey }
+    const existingEntry = Object.values(oneTimeAddresses).find((entry) =>
+      Number.isSafeInteger(entry.identityIndex) && entry.identityIndex === nextIdentityIndex
+    )
+
+    if (existingEntry != null) {
+      return existingEntry
+    }
+
+    const wallet = await this.walletRepository.getCurrent()
+
+    if (wallet == null) {
+      throw new Error('Wallet is not chosen')
+    }
+
+    let privateKeyWASM: PrivateKeyWASM
+
+    if (wallet.type === WalletType.seedphrase) {
+      if (typeof password !== 'string' || password.length === 0) {
+        throw new Error('Password is required to derive a deterministic registration address')
+      }
+
+      privateKeyWASM = await deriveSeedphraseRegistrationFundingPrivateKey(
+        wallet,
+        password,
+        nextIdentityIndex,
+        this.sdk
+      )
+    } else {
+      privateKeyWASM = PrivateKeyWASM.fromHex(generateSecureHex(32), network)
+    }
+
+    const address = this.sdk.keyPair.p2pkhAddress(privateKeyWASM.getPublicKey().bytes(), network as Network)
+    const encryptedPrivateKey = bytesToHex(encrypt(passwordPublicKey, hexToBytes(privateKeyWASM.hex())))
+
+    const entry: OneTimeAddressSchema = {
+      address,
+      encryptedPrivateKey,
+      identityIndex: nextIdentityIndex
+    }
 
     oneTimeAddresses[address] = entry
 
@@ -60,4 +100,29 @@ export class OneTimeAddressesRepository {
 
     return oneTimeAddresses[address] ?? null
   }
+
+  async removeByAddress (address: string): Promise<void> {
+    const network = await this.storageAdapter.get('network') as string
+    const walletId = await this.storageAdapter.get('currentWalletId') as string | null
+
+    if (walletId == null) {
+      throw new Error('Wallet is not chosen')
+    }
+
+    const storageKey = `oneTimeAddresses_${network}_${walletId}`
+    const oneTimeAddresses = (await this.storageAdapter.get(storageKey) ?? {}) as OneTimeAddressesSchema
+
+    if (oneTimeAddresses[address] == null) {
+      return
+    }
+
+    delete oneTimeAddresses[address]
+    await this.storageAdapter.set(storageKey, oneTimeAddresses)
+  }
+}
+
+function generateSecureHex (byteLength: number): string {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
 }

--- a/src/content-script/services/identityRegistration.ts
+++ b/src/content-script/services/identityRegistration.ts
@@ -212,15 +212,10 @@ export const buildAssetLockFromPaymentTx = async (
   const rawTx = dapiTx.transaction as any
   // Force copy into a plain JS Uint8Array in case rawTx is backed by WASM memory
   const txBytes = Uint8Array.from(rawTx)
-  console.log('[buildAssetLockFromPaymentTx] txBytes length:', txBytes.byteLength, 'first10:', Array.from(txBytes.slice(0, 10)).map((b: any) => b.toString(16).padStart(2, '0')).join(' '))
   const paymentTx = Transaction.fromBytes(txBytes)
-  console.log('[buildAssetLockFromPaymentTx] Transaction.fromBytes OK')
-
-  console.log('[buildAssetLockFromPaymentTx] checking hash...')
   if (paymentTx.hash() !== paymentTxid) {
     throw new Error(`Transaction hash mismatch for ${paymentTxid}: transaction data is corrupt`)
   }
-  console.log('[buildAssetLockFromPaymentTx] hash OK')
 
   if (!dapiTx.isInstantLocked && !dapiTx.isChainLocked && dapiTx.confirmations < 1) {
     throw new Error(
@@ -236,7 +231,6 @@ export const buildAssetLockFromPaymentTx = async (
   if (outputIndex != null) {
     resolvedOutputIndex = outputIndex
   } else {
-    console.log('[buildAssetLockFromPaymentTx] detecting output index...')
     const expectedScriptHex = Output.createP2PKH(0n, oneTimeAddress).script.hex()
     resolvedOutputIndex = paymentTx.outputs.findIndex(
       o => o.script.hex() === expectedScriptHex
@@ -247,7 +241,6 @@ export const buildAssetLockFromPaymentTx = async (
       )
     }
   }
-  console.log('[buildAssetLockFromPaymentTx] resolvedOutputIndex:', resolvedOutputIndex)
 
   if (resolvedOutputIndex >= paymentTx.outputs.length) {
     throw new Error(
@@ -256,7 +249,6 @@ export const buildAssetLockFromPaymentTx = async (
   }
 
   const paymentOutput = paymentTx.outputs[resolvedOutputIndex]
-  console.log('[buildAssetLockFromPaymentTx] paymentOutput.satoshis:', paymentOutput.satoshis)
 
   const privateKey = PrivateKey.fromWIF(oneTimePrivateKeyWif)
   const lockingScript = Output.createP2PKH(0n, privateKey.getAddress()).script
@@ -279,7 +271,6 @@ export const buildAssetLockFromPaymentTx = async (
   const sizeFee = BigInt(dummyTx.bytes().byteLength) * BigInt(FEE_PER_BYTE)
   const fee = sizeFee > MIN_FEE_RELAY ? sizeFee : MIN_FEE_RELAY
   const lockedAmount = paymentOutput.satoshis - fee
-  console.log('[buildAssetLockFromPaymentTx] dummyTx bytes:', dummyTx.bytes().byteLength, 'fee:', fee, 'lockedAmount:', lockedAmount)
 
   if (lockedAmount <= 0n) {
     throw new Error(
@@ -290,7 +281,6 @@ export const buildAssetLockFromPaymentTx = async (
 
   // Build final tx with correct lockedAmount and no change output.
   // The miner fee is implicit: totalInput - lockedAmount = fee.
-  console.log('[buildAssetLockFromPaymentTx] building final asset lock tx...')
   const payloadOutput = Output.createP2PKH(lockedAmount, oneTimeAddress)
   const assetLockTx = new Transaction(
     [],
@@ -302,7 +292,6 @@ export const buildAssetLockFromPaymentTx = async (
   )
   assetLockTx.addInput(new Input(paymentTxid, resolvedOutputIndex, new Script(), 0))
   assetLockTx.signInputs([{ inputIndex: 0, privateKey, lockingScript }])
-  console.log('[buildAssetLockFromPaymentTx] final asset lock tx OK, hash:', assetLockTx.hash())
 
   return {
     assetLockTx,
@@ -368,9 +357,6 @@ export const waitForAssetLockProof = async (
       try {
         const dapiTx = await coreSDK.getTransaction(txid)
 
-        console.log("isInstantLocked", dapiTx.isInstantLocked);
-        console.log("isChainLocked", dapiTx.isChainLocked);
-
         if (dapiTx.isChainLocked) {
           const requiredPlatformHeight = dapiTx.height
 
@@ -414,7 +400,7 @@ export const waitForAssetLockProof = async (
   }
 
   const result = await Promise.race([
-    // instantLockRace(),
+    instantLockRace(),
     chainLockRace()
   ])
 

--- a/src/content-script/services/identityRegistration.ts
+++ b/src/content-script/services/identityRegistration.ts
@@ -327,13 +327,15 @@ export const waitForAssetLockProof = async (
   txid: string,
   creditOutputAddress: string,
   pollIntervalMs: number = LOCK_POLL_INTERVAL_MS,
-  timeoutMs: number = LOCK_TIMEOUT_MS
+  timeoutMs: number = LOCK_TIMEOUT_MS,
+  subscription?: ReturnType<DashCoreSDK['subscribeToTransactions']>
 ): Promise<AssetLockProof> => {
   let settled = false
 
   // ── Race 1: instant lock via subscription ────────────────────────────────
   const instantLockRace = async (): Promise<AssetLockProof> => {
-    for await (const event of coreSDK.subscribeToTransactions([creditOutputAddress])) {
+    const sub = subscription ?? coreSDK.subscribeToTransactions([creditOutputAddress])
+    for await (const event of sub) {
       if (settled) return await Promise.reject(new Error('cancelled'))
 
       if (event.event !== 'instantSendLockMessage') continue

--- a/src/content-script/services/identityRegistration.ts
+++ b/src/content-script/services/identityRegistration.ts
@@ -11,6 +11,7 @@ import {
   TransactionType
 } from 'dash-core-sdk'
 import type { TransactionInputToSign, InstantAssetLockProofParams, ChainAssetLockProofParams } from 'dash-core-sdk'
+import type { DashPlatformSDK } from 'dash-platform-sdk'
 import { PrivateKeyWASM } from 'dash-platform-sdk/types'
 import hash from 'hash.js'
 import { decrypt } from 'eciesjs'
@@ -323,6 +324,7 @@ export type AssetLockProof = InstantAssetLockProofParams | ChainAssetLockProofPa
  */
 export const waitForAssetLockProof = async (
   coreSDK: DashCoreSDK,
+  platformSDK: DashPlatformSDK,
   assetLockTx: Transaction,
   txid: string,
   creditOutputAddress: string,
@@ -366,12 +368,35 @@ export const waitForAssetLockProof = async (
       try {
         const dapiTx = await coreSDK.getTransaction(txid)
 
+        console.log("isInstantLocked", dapiTx.isInstantLocked);
+        console.log("isChainLocked", dapiTx.isChainLocked);
+
         if (dapiTx.isChainLocked) {
-          return {
-            type: 'chainLock' as const,
-            txid,
-            outputIndex: 0,
-            coreChainLockedHeight: dapiTx.height
+          const requiredPlatformHeight = dapiTx.height
+
+          while (Date.now() < deadline) {
+            if (settled) return await Promise.reject(new Error('cancelled'))
+
+            try {
+              const nodeStatus = await platformSDK.node.status()
+              const latestPlatformHeight = nodeStatus.chain?.coreChainLockedHeight ?? 0
+
+              if (
+                Number.isSafeInteger(latestPlatformHeight) &&
+                latestPlatformHeight >= requiredPlatformHeight
+              ) {
+                return {
+                  type: 'chainLock' as const,
+                  txid,
+                  outputIndex: 0,
+                  coreChainLockedHeight: dapiTx.height
+                }
+              }
+            } catch {
+              // Transient DAPI error — keep polling
+            }
+
+            await wait(pollIntervalMs)
           }
         }
       } catch {
@@ -389,7 +414,7 @@ export const waitForAssetLockProof = async (
   }
 
   const result = await Promise.race([
-    instantLockRace(),
+    // instantLockRace(),
     chainLockRace()
   ])
 

--- a/src/content-script/services/identityRegistration.ts
+++ b/src/content-script/services/identityRegistration.ts
@@ -197,7 +197,7 @@ export interface AssetLockBuildResult {
 export const buildAssetLockFromPaymentTx = async (
   options: BuildAssetLockFromPaymentOptions
 ): Promise<AssetLockBuildResult> => {
-  const { coreSDK, network, paymentTxid, oneTimeAddress, oneTimePrivateKeyWif, outputIndex } = options
+  const { coreSDK, paymentTxid, oneTimeAddress, oneTimePrivateKeyWif, outputIndex } = options
 
   // Load the payment transaction from DAPI
   let dapiTx: Awaited<ReturnType<DashCoreSDK['getTransaction']>>
@@ -208,11 +208,18 @@ export const buildAssetLockFromPaymentTx = async (
     throw new Error(`Could not load payment transaction ${paymentTxid}: ${e instanceof Error ? e.message : String(e)}`)
   }
 
-  const paymentTx = Transaction.fromBytes(dapiTx.transaction)
+  const rawTx = dapiTx.transaction as any
+  // Force copy into a plain JS Uint8Array in case rawTx is backed by WASM memory
+  const txBytes = Uint8Array.from(rawTx)
+  console.log('[buildAssetLockFromPaymentTx] txBytes length:', txBytes.byteLength, 'first10:', Array.from(txBytes.slice(0, 10)).map((b: any) => b.toString(16).padStart(2, '0')).join(' '))
+  const paymentTx = Transaction.fromBytes(txBytes)
+  console.log('[buildAssetLockFromPaymentTx] Transaction.fromBytes OK')
 
+  console.log('[buildAssetLockFromPaymentTx] checking hash...')
   if (paymentTx.hash() !== paymentTxid) {
     throw new Error(`Transaction hash mismatch for ${paymentTxid}: transaction data is corrupt`)
   }
+  console.log('[buildAssetLockFromPaymentTx] hash OK')
 
   if (!dapiTx.isInstantLocked && !dapiTx.isChainLocked && dapiTx.confirmations < 1) {
     throw new Error(
@@ -222,8 +229,24 @@ export const buildAssetLockFromPaymentTx = async (
   }
 
   // Locate the output that pays to the one-time address.
-  // The caller should pass outputIndex when known; fallback is index 0.
-  const resolvedOutputIndex: number = outputIndex ?? 0
+  // If outputIndex is provided, use it; otherwise scan outputs for the one
+  // whose P2PKH script matches oneTimeAddress.
+  let resolvedOutputIndex: number
+  if (outputIndex != null) {
+    resolvedOutputIndex = outputIndex
+  } else {
+    console.log('[buildAssetLockFromPaymentTx] detecting output index...')
+    const expectedScriptHex = Output.createP2PKH(0n, oneTimeAddress).script.hex()
+    resolvedOutputIndex = paymentTx.outputs.findIndex(
+      o => o.script.hex() === expectedScriptHex
+    )
+    if (resolvedOutputIndex === -1) {
+      throw new Error(
+        `Could not find output paying to ${oneTimeAddress} in transaction ${paymentTxid}`
+      )
+    }
+  }
+  console.log('[buildAssetLockFromPaymentTx] resolvedOutputIndex:', resolvedOutputIndex)
 
   if (resolvedOutputIndex >= paymentTx.outputs.length) {
     throw new Error(
@@ -232,29 +255,30 @@ export const buildAssetLockFromPaymentTx = async (
   }
 
   const paymentOutput = paymentTx.outputs[resolvedOutputIndex]
+  console.log('[buildAssetLockFromPaymentTx] paymentOutput.satoshis:', paymentOutput.satoshis)
 
-  const utxos = [
-    {
-      txid: paymentTxid,
-      vout: resolvedOutputIndex,
-      satoshis: paymentOutput.satoshis,
-      privateKeyWif: oneTimePrivateKeyWif
-    }
-  ]
+  const privateKey = PrivateKey.fromWIF(oneTimePrivateKeyWif)
+  const lockingScript = Output.createP2PKH(0n, privateKey.getAddress()).script
 
-  // Build a draft transaction to measure its signed byte size.
-  // Satoshis values are fixed-width (int64) in serialization, so the size
-  // does not depend on the locked amount — the draft gives an accurate estimate.
-  const draftTx = buildAssetLockTransaction({
-    network,
-    utxos,
-    creditOutputs: [{ address: oneTimeAddress, amountSatoshis: MIN_FEE_RELAY }],
-    changeAddress: oneTimeAddress
-  })
+  // Build a dummy signed tx to measure byte size for fee calculation.
+  // Amounts are fixed-width (int64) in serialization, so any dummy lockedAmount gives
+  // the exact same byte length as the real tx.
+  const dummyPayloadOutput = Output.createP2PKH(MIN_FEE_RELAY, oneTimeAddress)
+  const dummyTx = new Transaction(
+    [],
+    [Output.createAssetLockBurn(MIN_FEE_RELAY)],
+    undefined,
+    undefined,
+    TransactionType.TRANSACTION_ASSET_LOCK,
+    new ExtraPayload.AssetLockTx(1, 1, [dummyPayloadOutput])
+  )
+  dummyTx.addInput(new Input(paymentTxid, resolvedOutputIndex, new Script(), 0))
+  dummyTx.signInputs([{ inputIndex: 0, privateKey, lockingScript }])
 
-  const sizeFee = BigInt(draftTx.bytes().byteLength) * BigInt(FEE_PER_BYTE)
+  const sizeFee = BigInt(dummyTx.bytes().byteLength) * BigInt(FEE_PER_BYTE)
   const fee = sizeFee > MIN_FEE_RELAY ? sizeFee : MIN_FEE_RELAY
   const lockedAmount = paymentOutput.satoshis - fee
+  console.log('[buildAssetLockFromPaymentTx] dummyTx bytes:', dummyTx.bytes().byteLength, 'fee:', fee, 'lockedAmount:', lockedAmount)
 
   if (lockedAmount <= 0n) {
     throw new Error(
@@ -263,16 +287,21 @@ export const buildAssetLockFromPaymentTx = async (
     )
   }
 
-  // If the size-based fee equals MIN_FEE_RELAY the draft already used the right
-  // locked amount, otherwise rebuild with the corrected value.
-  const assetLockTx = fee === MIN_FEE_RELAY
-    ? draftTx
-    : buildAssetLockTransaction({
-      network,
-      utxos,
-      creditOutputs: [{ address: oneTimeAddress, amountSatoshis: lockedAmount }],
-      changeAddress: oneTimeAddress
-    })
+  // Build final tx with correct lockedAmount and no change output.
+  // The miner fee is implicit: totalInput - lockedAmount = fee.
+  console.log('[buildAssetLockFromPaymentTx] building final asset lock tx...')
+  const payloadOutput = Output.createP2PKH(lockedAmount, oneTimeAddress)
+  const assetLockTx = new Transaction(
+    [],
+    [Output.createAssetLockBurn(lockedAmount)],
+    undefined,
+    undefined,
+    TransactionType.TRANSACTION_ASSET_LOCK,
+    new ExtraPayload.AssetLockTx(1, 1, [payloadOutput])
+  )
+  assetLockTx.addInput(new Input(paymentTxid, resolvedOutputIndex, new Script(), 0))
+  assetLockTx.signInputs([{ inputIndex: 0, privateKey, lockingScript }])
+  console.log('[buildAssetLockFromPaymentTx] final asset lock tx OK, hash:', assetLockTx.hash())
 
   return {
     assetLockTx,

--- a/src/content-script/storage/storageSchema.ts
+++ b/src/content-script/storage/storageSchema.ts
@@ -60,6 +60,7 @@ export interface AppConnectsStorageSchema {
 export interface OneTimeAddressSchema {
   address: string
   encryptedPrivateKey: string
+  identityIndex: number
 }
 
 export interface OneTimeAddressesSchema {

--- a/src/types/messages/payloads/RequestOneTimeAddressPayload.ts
+++ b/src/types/messages/payloads/RequestOneTimeAddressPayload.ts
@@ -1,0 +1,7 @@
+export interface RequestOneTimeAddressPayload {
+  /**
+   * Extension password. Required for seedphrase wallets to derive
+   * deterministic registration funding keys (DIP-0013).
+   */
+  password?: string
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -43,6 +43,17 @@ export const generateWalletId = (): string => {
 
 export const generateRandomHex = (size: number): string => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('')
 
+export const getNextIdentityIndex = (existingIndices: number[]): number => {
+  const occupied = new Set(existingIndices.filter((index) => Number.isSafeInteger(index) && index >= 0))
+  let candidate = 0
+
+  while (occupied.has(candidate)) {
+    candidate += 1
+  }
+
+  return candidate
+}
+
 export const validateIdentifier = (str: string): boolean => {
   try {
     const bytes = base58.decode(str)
@@ -100,13 +111,52 @@ export const deriveSeedphrasePrivateKey = async (wallet: Wallet, password: strin
   }
 
   const seed = await sdk.keyPair.mnemonicToSeed(mnemonic, undefined)
-  const walletHDKey = sdk.keyPair.seedToHdKey(seed)
+  const walletHDKey = sdk.keyPair.seedToHdKey(seed, Network[wallet.network as keyof typeof Network])
 
   const hdKey = sdk.keyPair.deriveIdentityPrivateKey(walletHDKey, identityIndex, keyId, Network[wallet.network])
   const privateKey = hdKey.privateKey
 
   if (privateKey == null) {
     throw new Error('Could not derive private key from wallet hd key')
+  }
+
+  return PrivateKeyWASM.fromBytes(privateKey, wallet.network)
+}
+
+export const deriveSeedphraseRegistrationFundingPrivateKey = async (
+  wallet: Wallet,
+  password: string,
+  identityIndex: number,
+  sdk: DashPlatformSDK
+): Promise<PrivateKeyWASM> => {
+  if (wallet.encryptedMnemonic == null) {
+    throw new Error('Missing mnemonic')
+  }
+
+  if (!Number.isSafeInteger(identityIndex) || identityIndex < 0) {
+    throw new Error('Identity index must be a non-negative integer')
+  }
+
+  const passwordHash = hash.sha256().update(password).digest('hex')
+  const secretKey = PrivateKey.fromHex(passwordHash)
+
+  let mnemonic
+
+  try {
+    mnemonic = bytesToUtf8(decrypt(secretKey.toHex(), hexToBytes(wallet.encryptedMnemonic)))
+  } catch (e) {
+    throw new Error('Failed to decrypt')
+  }
+
+  const seed = await sdk.keyPair.mnemonicToSeed(mnemonic, undefined)
+  const walletHDKey = sdk.keyPair.seedToHdKey(seed, Network[wallet.network])
+  const networkIndex = wallet.network === 'mainnet' ? 5 : 1
+  const path = `m/9'/${networkIndex}'/5'/1'/${identityIndex}`
+  const hdKey = await sdk.keyPair.derivePath(walletHDKey, path)
+  const privateKey = hdKey.privateKey
+
+  if (privateKey == null) {
+    throw new Error('Could not derive registration funding private key from wallet hd key')
   }
 
   return PrivateKeyWASM.fromBytes(privateKey, wallet.network)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,9 +3749,9 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-"dash-core-sdk@https://github.com/pshenmic/dash-core-sdk#cd541b0f788b66d32be3697a8e4dd155ae7f6ca6":
+"dash-core-sdk@https://github.com/pshenmic/dash-core-sdk#4e536a88a76deccae1a987ad965b0a8b5991de86":
   version "1.1.2"
-  resolved "https://github.com/pshenmic/dash-core-sdk#cd541b0f788b66d32be3697a8e4dd155ae7f6ca6"
+  resolved "https://github.com/pshenmic/dash-core-sdk#4e536a88a76deccae1a987ad965b0a8b5991de86"
   dependencies:
     "@dashevo/x11-hash-js" "^1.0.2"
     "@noble/curves" "^2.0.1"
@@ -3766,10 +3766,10 @@ csstype@^3.0.2:
     typescript "^5.9.2"
     ws "^8.18.3"
 
-dash-platform-sdk@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/dash-platform-sdk/-/dash-platform-sdk-1.3.1.tgz"
-  integrity sha512-tw03XKDGvyvsI7ey6CvDbvFb71MVqGcRnV83EFF8Fx8tl+azXUc/fjZQiK/aWNAe0a16/sphBKALzgIOl7Z70A==
+dash-platform-sdk@1.3.2-dev.3:
+  version "1.3.2-dev.3"
+  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.3.2-dev.3.tgz#7406cb4b93b3c80aa0f99e4627749e40728ea046"
+  integrity sha512-m1waDIgb+xoTqTIsES9/3tshwv6y3zaRdBYg3R8CLekCZJlOxFkSzk45ekaoEPVfWrG8tES4zlFZ+Q+gdKaQWA==
   dependencies:
     "@bufbuild/protobuf" "^2.6.0"
     "@protobuf-ts/grpcweb-transport" "^2.11.1"
@@ -3778,7 +3778,7 @@ dash-platform-sdk@1.3.1:
     "@scure/bip39" "^2.0.0"
     "@scure/btc-signer" "^2.0.1"
     cbor-x "^1.6.0"
-    pshenmic-dpp "1.1.2-dev.8"
+    pshenmic-dpp "1.1.2-dev.10"
 
 dash-ui-kit@2.1.0-dev:
   version "2.1.0-dev"
@@ -6954,10 +6954,10 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-pshenmic-dpp@1.1.2-dev.8:
-  version "1.1.2-dev.8"
-  resolved "https://registry.npmjs.org/pshenmic-dpp/-/pshenmic-dpp-1.1.2-dev.8.tgz"
-  integrity sha512-P3czQ6uJYHr7XJ2OSWUH+FNej7Qpa+bz8Ld7+FtUqjGCBpwK6GTGQy1PDmACT9nP8+DXpFTUGu7Au9u66kvcdA==
+pshenmic-dpp@1.1.2-dev.10:
+  version "1.1.2-dev.10"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.1.2-dev.10.tgz#3abc4ba0f31ac48fafe23bd6f34f2b864daa5eb3"
+  integrity sha512-2S1eF5UjhOrEJ5cLn2YBk2k/TNDFipO2cLDHbpMGOhy//NcoFIPIZfo2l6n01dA0fCOLDpjHa/1smrVABUAGkg==
   dependencies:
     fflate "^0.8.2"
 


### PR DESCRIPTION
## Summary

Fix identity registration flow to correctly support both asset lock proof types: `instantLock` and `chainLock`.

## What changed

- Kept `instantLock` path as the fast path via transaction subscription.
- Improved `chainLock` path:
  - wait until `coreSDK.getTransaction(txid)` reports `isChainLocked`,
  - then start polling `platformSDK.node.status()`,
  - return chain lock proof only after Platform reaches the required block height (`latestBlockHeight >= core chain-locked height`).

## Why

This removes the Core/Platform height race during identity creation and prevents premature `chainLock` proof usage when Platform is still behind.

## Verification

- `npm run build` passes successfully.
