### PR TITLE
Disable username registration for masternode identities

### DIFF
--- a/src/ui/states/home/HomeState.tsx
+++ b/src/ui/states/home/HomeState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useMemo } from 'react'
 import { useNavigate, useOutletContext } from 'react-router-dom'
 import NoIdentities from './NoIdentities'
 import NoWallets from './NoWallets'
@@ -9,6 +9,7 @@ import { useExtensionAPI, useAsyncState, useSdk } from '../../hooks'
 import { withAccessControl } from '../../components/auth/withAccessControl'
 import { usePlatformExplorerClient, type TransactionData, type NetworkType } from '../../hooks/usePlatformExplorerApi'
 import { type TokenData } from '../../../types'
+import { IdentityType } from '../../../types/enums/IdentityType'
 import type { OutletContext } from '../../types/OutletContext'
 import { TransactionsList } from '../../components/transactions'
 import { TokensList } from '../../components/tokens'
@@ -22,7 +23,7 @@ function HomeState (): React.JSX.Element {
   const extensionAPI = useExtensionAPI()
   const sdk = useSdk()
   const platformExplorerClient = usePlatformExplorerClient()
-  const { currentNetwork, currentWallet, currentIdentity, setCurrentIdentity, allWallets } = useOutletContext<OutletContext>()
+  const { currentNetwork, currentWallet, currentIdentity, setCurrentIdentity, allWallets, availableIdentities } = useOutletContext<OutletContext>()
   const [identities, setIdentities] = useState<string[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [transactionsState, loadTransactions] = useAsyncState<TransactionData[]>()
@@ -30,6 +31,18 @@ function HomeState (): React.JSX.Element {
   const [namesState, loadNames] = useAsyncState<NameData[]>()
   const [balanceState, loadBalance] = useAsyncState<bigint>()
   const [rateState, loadRate] = useAsyncState<number>()
+  const [activeTab, setActiveTab] = useState('transactions')
+
+  const isMasternodeIdentity = useMemo(() => {
+    const identity = availableIdentities.find(i => i.identifier === currentIdentity)
+    return identity?.type === IdentityType.masternode
+  }, [availableIdentities, currentIdentity])
+
+  useEffect(() => {
+    if (isMasternodeIdentity && activeTab === 'names') {
+      setActiveTab('transactions')
+    }
+  }, [isMasternodeIdentity, activeTab])
 
   useEffect(() => {
     const loadIdentities = async (): Promise<void> => {
@@ -210,7 +223,8 @@ function HomeState (): React.JSX.Element {
         className='relative z-5  flex flex-col flex-grow gap-6 -mx-[0.875rem] -mb-[0.875rem] !rounded-b-none p-4 dash-shadow-lg'
       >
         <Tabs
-          defaultValue='transactions'
+          value={activeTab}
+          onValueChange={setActiveTab}
           items={[
             {
               value: 'transactions',
@@ -241,6 +255,7 @@ function HomeState (): React.JSX.Element {
             {
               value: 'names',
               label: 'Names',
+              disabled: isMasternodeIdentity,
               content: (
                 <NamesList
                   names={namesState.data ?? []}

--- a/src/ui/states/nameRegistration/index.tsx
+++ b/src/ui/states/nameRegistration/index.tsx
@@ -10,6 +10,7 @@ import { ConfirmationStep } from './ConfirmationStep'
 import { MissingRequiredKeyWarning, type KeyRequirement } from '../../components/keys'
 import { isKeyCompatible, creditsToDash } from '../../../utils'
 import { CONTESTED_NAME_COST_DASH, REGULAR_NAME_COST_DASH, NAME_SUFFIX } from './constants'
+import { IdentityType } from '../../../types/enums/IdentityType'
 type Step = 1 | 2
 
 const NameRegistrationState: React.FC = () => {
@@ -17,7 +18,11 @@ const NameRegistrationState: React.FC = () => {
   const navigate = useNavigate()
   const extensionAPI = useExtensionAPI()
   const [currentStep, setCurrentStep] = useState<Step>(1)
-  const { currentNetwork, currentIdentity } = useOutletContext<LayoutContext>()
+  const { currentNetwork, currentIdentity, availableIdentities } = useOutletContext<LayoutContext>()
+
+  const currentIdentityObj = availableIdentities.find(i => i.identifier === currentIdentity)
+  const isMasternodeIdentity = currentIdentityObj?.type === IdentityType.masternode
+
   const keyRequirements: KeyRequirement[] = [
     { purpose: 'AUTHENTICATION', securityLevel: 'HIGH' }
   ]
@@ -196,7 +201,7 @@ const NameRegistrationState: React.FC = () => {
   }, [currentStep, username, handleUsernameChange])
 
   return (
-    <div className='flex flex-col h-full min-h-max'>
+    <div className='flex flex-col h-full min-h-max relative'>
       <TitleBlock
         title={<>{currentStep === 1 ? 'Create' : 'Confirm'} your<br />Dash Username</>}
         description={currentStep === 1
@@ -247,6 +252,20 @@ const NameRegistrationState: React.FC = () => {
                 ? 'Username must be at least 3 characters and contain only letters, numbers, hyphens, and underscores'
                 : 'This username is already taken. Please choose a different one.'}
         </ValueCard>
+      )}
+
+      {isMasternodeIdentity && (
+        <div className='absolute inset-0 !-left-4 !-right-4 z-50 flex flex-col items-center justify-center rounded-2xl backdrop-blur-sm bg-white/80'>
+          <ValueCard border={false} className='flex flex-col items-center gap-3 text-center max-w-[280px] dash-shadow-xl'>
+            <InfoCircleIcon className='w-8 h-8 text-dash-primary-dark-blue/60 flex-shrink-0' />
+            <Text weight='bold' size='sm'>
+              Name Registration Unavailable
+            </Text>
+            <Text size='xs' dim>
+              Name registration is not available for masternode identities. Please switch to a regular identity to register a username.
+            </Text>
+          </ValueCard>
+        </div>
       )}
 
       <div className='flex flex-col gap-4 w-full mt-6 relative'>


### PR DESCRIPTION
# Issue
It is necessary to restrict the name registration interface for masternode identities

# Things done
A name registration restriction for masternode identities has been added to the UI:
- Added message on name registration screens
- Disabled Names tab on the home screen