### PR TITLE
fix(identity): use DIP-0013 registration key for credit output and ST signing

### DIFF
--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -17,6 +17,7 @@ import { waitForAssetLockProof } from '../../../../utils/waitForAssetLockProof'
 import { IDENTITY_KEY_DEFINITIONS, buildIdentityCreateTransition } from '../../../../utils/identityRegistration'
 import {
   deriveIdentityPrivateKey,
+  deriveIdentityRegistrationKey,
   findNextLocalIdentityIndex,
   hexToBytes
 } from '../../../../utils'
@@ -77,11 +78,9 @@ export class RegisterIdentityHandler implements APIHandler {
     }
 
     // ── 3. Decrypt the one-time funding key ─────────────────────────────────
-    // Per DIP-0011 the registration key (signs IdentityCreateTransition and
-    // owns the asset lock credit output) must be single-use. The key was
-    // generated as random 256-bit at requestAssetLockFundingAddress time and
-    // serves three roles: signs the asset lock tx input, owns the credit
-    // output, signs the IdentityCreateTransition.
+    // The funding key signs the asset lock tx inputs only. Credit output
+    // ownership and Platform ST signing are handled by identityRegistrationKey
+    // derived in step 5 (DIP-0013).
     const passwordHash = hash.sha256().update(payload.password).digest('hex')
     const secretKey = PrivateKey.fromHex(passwordHash)
 
@@ -117,14 +116,21 @@ export class RegisterIdentityHandler implements APIHandler {
       identityIndex++
     }
 
-    // ── 5. Build asset lock transaction ─────────────────────────────────────
-    // Input + credit output both use the one-time funding address. The build
-    // is deterministic so the same inputs produce the same txid on retry.
+    // ── 5. Derive identity registration key (DIP-0013 path 5'/1'/index) ────
+    // This key owns the asset lock credit output and signs the
+    // IdentityCreateTransition. Derived from seed — recoverable without storage.
+    const identityRegistrationKey = await deriveIdentityRegistrationKey(wallet, payload.password, identityIndex, this.sdk)
+    const creditOutputAddress = this.sdk.keyPair.p2pkhAddress(identityRegistrationKey.getPublicKey().bytes(), wallet.network as any)
+
+    // ── 6. Build asset lock transaction ─────────────────────────────────────
+    // Inputs are signed by the one-time funding key. Credit output goes to
+    // creditOutputAddress (registration key). Build is deterministic on retry.
     const { assetLockTx } = await buildAssetLockFromFundingTx(
       this.coreSDK,
       payload.assetLockFundingTxid,
       payload.assetLockFundingAddress,
-      assetLockFundingPrivateKey.WIF()
+      assetLockFundingPrivateKey.WIF(),
+      creditOutputAddress
     )
 
     const assetLockTxid = assetLockTx.hash()
@@ -139,7 +145,7 @@ export class RegisterIdentityHandler implements APIHandler {
       )
     }
 
-    // ── 6. Broadcast the asset lock transaction (skip if already broadcast) ─
+    // ── 7. Broadcast the asset lock transaction (skip if already broadcast) ─
     // The instant lock subscription is opened in both fresh and recovery modes
     // because waitForAssetLockProof needs it to receive instant lock events
     // for txs that are not yet chain-locked.
@@ -155,7 +161,7 @@ export class RegisterIdentityHandler implements APIHandler {
       await this.assetLockFundingAddressesRepository.markAsBroadcasted(payload.assetLockFundingAddress, assetLockTxid)
     }
 
-    // ── 7. Wait for instant lock or chain lock (whichever comes first) ──────
+    // ── 8. Wait for instant lock or chain lock (whichever comes first) ──────
     const assetLockProof = await waitForAssetLockProof(
       this.coreSDK,
       this.sdk,
@@ -164,7 +170,7 @@ export class RegisterIdentityHandler implements APIHandler {
       instantLockSub
     )
 
-    // ── 8. Derive all identity key pairs (HD-derived for recoverability) ────
+    // ── 9. Derive all identity key pairs (HD-derived for recoverability) ────
     const identityPrivateKeys: PrivateKeyWASM[] = []
 
     for (const { id } of IDENTITY_KEY_DEFINITIONS) {
@@ -173,16 +179,17 @@ export class RegisterIdentityHandler implements APIHandler {
       )
     }
 
-    // ── 9. Build and sign identity create state transition ──────────────────
-    // Signed by the one-time funding key (= asset lock credit output owner).
+    // ── 10. Build and sign identity create state transition ─────────────────
+    // Signed by the identity registration key (DIP-0013) which owns the credit
+    // output. The funding key is not used for Platform signing.
     const stateTransition = buildIdentityCreateTransition(
       identityPrivateKeys,
-      assetLockFundingPrivateKey,
+      identityRegistrationKey,
       assetLockProof,
       this.sdk
     )
 
-    // ── 10. Derive the new identity identifier ──────────────────────────────
+    // ── 11. Derive the new identity identifier ──────────────────────────────
     const identifier = stateTransition.getOwnerId()?.base58()
 
     if (identifier == null || identifier === '') {
@@ -191,7 +198,7 @@ export class RegisterIdentityHandler implements APIHandler {
 
     const stateTransitionHash: string = stateTransition.hash(false)
 
-    // ── 11. Persist identity in repo before broadcasting the state transition.
+    // ── 12. Persist identity in repo before broadcasting the state transition.
     // If the broadcast fails with a non-idempotent error we roll back this
     // record so the local state never contains a phantom identity. If the
     // identifier is already present (e.g. previous attempt reached this step),
@@ -204,7 +211,7 @@ export class RegisterIdentityHandler implements APIHandler {
       wasJustCreated = true
     }
 
-    // ── 12. Broadcast the state transition ──────────────────────────────────
+    // ── 13. Broadcast the state transition ──────────────────────────────────
     let alreadyOnPlatform = false
 
     try {
@@ -220,12 +227,12 @@ export class RegisterIdentityHandler implements APIHandler {
       }
     }
 
-    // ── 13. Wait for confirmation (skip if Platform already had the ST) ─────
+    // ── 14. Wait for confirmation (skip if Platform already had the ST) ─────
     if (!alreadyOnPlatform) {
       await this.sdk.stateTransitions.waitForStateTransitionResult(stateTransition)
     }
 
-    // ── 14. Mark funding address as used and switch identity ────────────────
+    // ── 15. Mark funding address as used and switch identity ────────────────
     await this.assetLockFundingAddressesRepository.markAsUsed(payload.assetLockFundingAddress)
     await this.walletRepository.switchIdentity(identifier)
 

--- a/src/utils/buildAssetLockFromFundingTx.ts
+++ b/src/utils/buildAssetLockFromFundingTx.ts
@@ -22,20 +22,22 @@ import {
  *  2. Confirm it's locked (instant/chain) or confirmed (>=1 confirmation)
  *  3. Aggregate ALL outputs paying to the asset lock funding address
  *  4. Build asset lock tx: one input per matching output, single credit
- *     output for the summed amount minus a fixed fee
+ *     output directed to creditOutputAddress
  *
  * Multiple matching outputs can occur when the sender's wallet uses coin
  * selection that produces several outputs to the same destination address
  * (e.g. dust). Ignoring extras would silently lose funds.
  *
- * The funding key is single-use per DIP-0011: it signs every input, owns
- * the credit output, and later signs the IdentityCreateTransition.
+ * The funding key signs every input. The credit output is owned by a
+ * separate key (per DIP-0013): the identity registration or top-up key
+ * derived from the wallet seed. That key later signs the Platform ST.
  */
 export const buildAssetLockFromFundingTx = async (
   coreSDK: DashCoreSDK,
   assetLockFundingTxid: string,
   assetLockFundingAddress: string,
-  assetLockFundingPrivateKeyWif: string
+  assetLockFundingPrivateKeyWif: string,
+  creditOutputAddress: string
 ): Promise<AssetLockBuildResult> => {
   const dapiTx = await coreSDK.getTransaction(assetLockFundingTxid).catch((e: unknown) => {
     throw new Error(`Could not load asset lock funding transaction ${assetLockFundingTxid}: ${e instanceof Error ? e.message : String(e)}`)
@@ -77,7 +79,7 @@ export const buildAssetLockFromFundingTx = async (
 
   const assetLockFundingPrivateKey = PrivateKey.fromWIF(assetLockFundingPrivateKeyWif)
   const lockingScript = Output.createP2PKH(0n, assetLockFundingPrivateKey.getAddress()).script
-  const creditOutput = Output.createP2PKH(lockedAmount, assetLockFundingAddress)
+  const creditOutput = Output.createP2PKH(lockedAmount, creditOutputAddress)
 
   const assetLockTx = new Transaction(
     [],

--- a/src/utils/decodeStateTransition.ts
+++ b/src/utils/decodeStateTransition.ts
@@ -6,8 +6,7 @@ import {
   MasternodeVoteTransitionWASM,
   DataContractUpdateTransitionWASM
 } from 'dash-platform-sdk/types'
-import { IdentityCreditWithdrawalTransitionWASM } from 'pshenmic-dpp'
-import { DataContractCreateTransitionWASM, PlatformVersionWASM } from 'pshenmic-dpp'
+import { IdentityCreditWithdrawalTransitionWASM, DataContractCreateTransitionWASM, PlatformVersionWASM } from 'pshenmic-dpp'
 import { StateTransitionTypeEnum, DocumentActionEnum, TokenActionEnum } from '../enums'
 import { DecodedStateTransition } from '../types'
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -109,6 +109,19 @@ export const decryptMnemonic = (wallet: Wallet, password: string): string => {
   }
 }
 
+export const deriveIdentityRegistrationKey = async (wallet: Wallet, password: string, identityIndex: number, sdk: DashPlatformSDK): Promise<PrivateKeyWASM> => {
+  const coinType = wallet.network === 'mainnet' ? 5 : 1
+  const seed = sdk.keyPair.mnemonicToSeed(decryptMnemonic(wallet, password))
+  const walletHDKey = sdk.keyPair.seedToHdKey(seed, wallet.network as any)
+  const { privateKey } = await sdk.keyPair.derivePath(walletHDKey, `m/9'/${coinType}'/5'/1'/${identityIndex}`)
+
+  if (privateKey == null) {
+    throw new Error('Could not derive identity registration key from wallet hd key')
+  }
+
+  return PrivateKeyWASM.fromBytes(privateKey, wallet.network)
+}
+
 export const deriveIdentityPrivateKey = async (wallet: Wallet, password: string, identityIndex: number, keyId: number, sdk: DashPlatformSDK): Promise<PrivateKeyWASM> => {
   const network = Network[wallet.network as keyof typeof Network]
   const seed = sdk.keyPair.mnemonicToSeed(decryptMnemonic(wallet, password))

--- a/test/api/private/identities/registerIdentity.spec.ts
+++ b/test/api/private/identities/registerIdentity.spec.ts
@@ -26,7 +26,8 @@ jest.mock('../../../../src/utils', () => {
   const actual = jest.requireActual('../../../../src/utils')
   return {
     ...actual,
-    deriveIdentityPrivateKey: jest.fn()
+    deriveIdentityPrivateKey: jest.fn(),
+    deriveIdentityRegistrationKey: jest.fn()
   }
 })
 
@@ -34,7 +35,7 @@ const buildAssetLockFromFundingTxMock = buildAssetLockFromFundingTx as jest.Mock
 const waitForAssetLockProofMock = waitForAssetLockProof as jest.MockedFunction<typeof waitForAssetLockProof>
 
 const { buildIdentityCreateTransition } = jest.requireMock('../../../../src/utils/identityRegistration')
-const { deriveIdentityPrivateKey } = jest.requireMock('../../../../src/utils')
+const { deriveIdentityPrivateKey, deriveIdentityRegistrationKey } = jest.requireMock('../../../../src/utils')
 
 describe('RegisterIdentityHandler', () => {
   const identifier = 'HT3pUBM1Uv2mKgdPEN1gxa7A4PdsvNY89aJbdSKQb5wR'
@@ -136,6 +137,9 @@ describe('RegisterIdentityHandler', () => {
         getIdentityByPublicKeyHash: jest.fn(async () => null),
         getIdentityByNonUniquePublicKeyHash: jest.fn(async () => null)
       },
+      keyPair: {
+        p2pkhAddress: jest.fn(() => 'yRegistrationAddress')
+      },
       stateTransitions: {
         broadcast: jest.fn(async () => {
           order.push('platformBroadcast')
@@ -157,6 +161,10 @@ describe('RegisterIdentityHandler', () => {
     })
 
     deriveIdentityPrivateKey.mockImplementation(async () => {
+      return PrivateKeyWASM.fromHex('3ca33236ab14f6df6cf87fcbb0551544fee7dcf4f251557af02c175725764a5a', 'testnet')
+    })
+
+    deriveIdentityRegistrationKey.mockImplementation(async () => {
       return PrivateKeyWASM.fromHex('3ca33236ab14f6df6cf87fcbb0551544fee7dcf4f251557af02c175725764a5a', 'testnet')
     })
 


### PR DESCRIPTION
## Summary

Fixes identity registration to correctly separate the asset-lock funding
key from the identity registration key per DIP-0013.

Previously the same random one-time key was used for both signing asset-lock
TX inputs and owning the credit output / signing IdentityCreateTransition.
This deviated from DIP-0013 which defines a dedicated HD-derived path for
the registration funding key.

- Add `deriveIdentityRegistrationKey` in `src/utils/index.ts` deriving
  from `m/9'/{coin_type}'/5'/1'/{identity_index}` (DIP-0013 sub-feature 1).
- Update `buildAssetLockFromFundingTx` to accept a separate
  `creditOutputAddress` parameter. The credit output is now directed to
  the registration key address instead of the funding address.
- Update `RegisterIdentityHandler` to derive the registration key after
  finding the identity index, pass its address as `creditOutputAddress`,
  and sign `IdentityCreateTransition` with it instead of the funding key.

The random funding key continues to sign asset-lock TX inputs only.
The registration key is HD-derived and therefore recoverable from seed.

## Test plan

- [x] `yarn test --testPathPattern='registerIdentity'` — 17/17 passing
- [x] `yarn lint` clean
