### PR TITLE
chore: bump dash-platform-sdk to 1.4.0-dev.13 for tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@scure/base": "^1.2.4",
     "@scure/bip39": "^1.6.0",
     "dash-core-sdk": "1.1.3-dev.1",
-    "dash-platform-sdk": "1.3.2-dev.3",
+    "dash-platform-sdk": "1.4.0-dev.11",
     "dash-ui-kit": "2.1.2",
     "eciesjs": "^0.4.15",
     "hash.js": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@scure/base": "^1.2.4",
     "@scure/bip39": "^1.6.0",
     "dash-core-sdk": "1.1.3-dev.1",
-    "dash-platform-sdk": "1.4.0-dev.11",
+    "dash-platform-sdk": "1.4.0-dev.13",
     "dash-ui-kit": "2.1.2",
     "eciesjs": "^0.4.15",
     "hash.js": "^1.1.7",
@@ -33,9 +33,6 @@
     "react-router": "^7.4.1",
     "react-router-dom": "^7.6.0",
     "sha256": "^0.2.0"
-  },
-  "resolutions": {
-    "pshenmic-dpp": "2.0.0-dev.17"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "react-router-dom": "^7.6.0",
     "sha256": "^0.2.0"
   },
+  "resolutions": {
+    "pshenmic-dpp": "2.0.0-dev.17"
+  },
   "devDependencies": {
     "@babel/core": "^7.23.5",
     "@babel/plugin-transform-modules-commonjs": "^7.27.1",

--- a/src/content-script/api/private/assetLocks/requestAssetLockFundingAddress.ts
+++ b/src/content-script/api/private/assetLocks/requestAssetLockFundingAddress.ts
@@ -46,7 +46,7 @@ export class RequestAssetLockFundingAddressHandler implements APIHandler {
       throw new Error('Password is not set for an extension')
     }
 
-    const privateKeyWASM = PrivateKeyWASM.fromHex(generateRandomHex(64), wallet.network)
+    const privateKeyWASM = PrivateKeyWASM.fromHex(generateRandomHex(64), wallet.network as Network)
     const address = this.sdk.keyPair.p2pkhAddress(privateKeyWASM.getPublicKey().bytes(), wallet.network as Network)
     const encryptedPrivateKey = bytesToHex(encrypt(passwordPublicKey, hexToBytes(privateKeyWASM.hex())))
 

--- a/src/content-script/api/private/identities/addPrivateKey.ts
+++ b/src/content-script/api/private/identities/addPrivateKey.ts
@@ -1,7 +1,7 @@
 import { IdentitiesRepository } from '../../../repository/IdentitiesRepository'
 import { EventData } from '../../../../types'
 import { APIHandler } from '../../APIHandler'
-import { PrivateKeyWASM } from 'dash-platform-sdk/types'
+import { Network, PrivateKeyWASM } from 'dash-platform-sdk/types'
 import { WalletRepository } from '../../../repository/WalletRepository'
 import { KeypairRepository } from '../../../repository/KeypairRepository'
 import { validateHex } from '../../../../utils'
@@ -35,7 +35,7 @@ export class AddIdentityPrivateKey implements APIHandler {
       throw new Error('Adding private key only possible in keystore wallet mode')
     }
 
-    const publicKeyHash = PrivateKeyWASM.fromHex(payload.privateKey, wallet.network).getPublicKeyHash()
+    const publicKeyHash = PrivateKeyWASM.fromHex(payload.privateKey, wallet.network as Network).getPublicKeyHash()
 
     // check identity exists
     const identity = await this.identitiesRepository.getByIdentifier(payload.identity)

--- a/src/content-script/api/private/identities/createIdentityPrivateKey.ts
+++ b/src/content-script/api/private/identities/createIdentityPrivateKey.ts
@@ -32,8 +32,7 @@ export class CreateIdentityPrivateKeyHandler implements APIHandler {
     const payload: CreateIdentityPrivateKeyPayload = event.payload
     const wallet = await this.walletRepository.getCurrent()
     const network = await this.storageAdapter.get('network') as string
-    // KeyType is a const enum in SDK 1.4 — dynamic lookup `KeyType[name]` is
-    // forbidden by TS, so map the validated payload value explicitly.
+    // Map explicitly — KeyType is a const enum, no dynamic `KeyType[name]` indexing.
     const keyType: KeyType = payload.keyType === 'ECDSA_SECP256K1'
       ? KeyType.ECDSA_SECP256K1
       : KeyType.ECDSA_HASH160

--- a/src/content-script/api/private/identities/createIdentityPrivateKey.ts
+++ b/src/content-script/api/private/identities/createIdentityPrivateKey.ts
@@ -9,7 +9,7 @@ import { KeypairRepository } from '../../../repository/KeypairRepository'
 import { StateTransitionsRepository } from '../../../repository/StateTransitionsRepository'
 import { CreateIdentityPrivateKeyPayload } from '../../../../types/messages/payloads/CreateIdentityPrivateKeyPayload'
 import { CreateIdentityPrivateKeyResponse } from '../../../../types/messages/response/CreateIdentityPrivateKeyResponse'
-import { IdentityPublicKeyInCreation, KeyType, PrivateKeyWASM } from 'dash-platform-sdk/types'
+import { IdentityPublicKeyInCreation, KeyType, Network, PrivateKeyWASM } from 'dash-platform-sdk/types'
 
 export class CreateIdentityPrivateKeyHandler implements APIHandler {
   walletRepository: WalletRepository
@@ -32,7 +32,11 @@ export class CreateIdentityPrivateKeyHandler implements APIHandler {
     const payload: CreateIdentityPrivateKeyPayload = event.payload
     const wallet = await this.walletRepository.getCurrent()
     const network = await this.storageAdapter.get('network') as string
-    const keyType = KeyType[payload.keyType]
+    // KeyType is a const enum in SDK 1.4 — dynamic lookup `KeyType[name]` is
+    // forbidden by TS, so map the validated payload value explicitly.
+    const keyType: KeyType = payload.keyType === 'ECDSA_SECP256K1'
+      ? KeyType.ECDSA_SECP256K1
+      : KeyType.ECDSA_HASH160
 
     if (wallet == null) {
       throw new Error('No wallet is chosen')
@@ -61,7 +65,7 @@ export class CreateIdentityPrivateKeyHandler implements APIHandler {
       if (existing) {
         privateKeyWASM = await this.keypairRepository.getPrivateKeyFromWallet(wallet, identity, nextKeyId, payload.password)
       } else {
-        privateKeyWASM = PrivateKeyWASM.fromHex(generateRandomHex(64), network)
+        privateKeyWASM = PrivateKeyWASM.fromHex(generateRandomHex(64), network as Network)
 
         await this.keypairRepository.add(identity.identifier, privateKeyWASM.hex(), nextKeyId, true)
       }
@@ -113,7 +117,7 @@ export class CreateIdentityPrivateKeyHandler implements APIHandler {
       // const signerIdentityPublicKey = identityWASM.getPublicKeys()[masterKeyId]
       // const signerPrivateKey = await this.keypairRepository.getPrivateKeyFromWallet(wallet, identity, masterKeyId, payload.password)
 
-      stateTransition.signByPrivateKey(privateKeyWASM, 0, payload.keyType)
+      stateTransition.signByPrivateKey(privateKeyWASM, 0, keyType)
 
       signature = stateTransition.signature
     }

--- a/src/content-script/api/private/identities/importIdentity.ts
+++ b/src/content-script/api/private/identities/importIdentity.ts
@@ -1,7 +1,7 @@
 import { IdentitiesRepository } from '../../../repository/IdentitiesRepository'
 import { EventData } from '../../../../types'
 import { APIHandler } from '../../APIHandler'
-import { IdentityPublicKeyWASM, PrivateKeyWASM } from 'dash-platform-sdk/types'
+import { IdentityPublicKeyWASM, Network, PrivateKeyWASM } from 'dash-platform-sdk/types'
 import { WalletRepository } from '../../../repository/WalletRepository'
 import { KeypairRepository } from '../../../repository/KeypairRepository'
 import { findNextLocalIdentityIndex, validateHex } from '../../../../utils'
@@ -48,14 +48,14 @@ export class ImportIdentityHandler implements APIHandler {
     if (!privateKeys
       .every(privateKey => identityPublicKeysWASM
         .some((identityPublicKey: IdentityPublicKeyWASM) => identityPublicKey.getPublicKeyHash() ===
-                PrivateKeyWASM.fromHex(privateKey, wallet.network).getPublicKeyHash()))) {
+                PrivateKeyWASM.fromHex(privateKey, wallet.network as Network).getPublicKeyHash()))) {
       throw new Error('One or more private keys does not match to any of known identity\'s public keys')
     }
 
     for (const privateKey of privateKeys) {
       const [identityPublicKey] = identityPublicKeysWASM
         .filter((identityPublicKey: IdentityPublicKeyWASM) => identityPublicKey.getPublicKeyHash() ===
-              PrivateKeyWASM.fromHex(privateKey, wallet.network).getPublicKeyHash())
+              PrivateKeyWASM.fromHex(privateKey, wallet.network as Network).getPublicKeyHash())
 
       await this.keypairRepository.add(payload.identity, privateKey, identityPublicKey.keyId)
     }

--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -1,5 +1,5 @@
 import { DashCoreSDK } from 'dash-core-sdk'
-import { PrivateKeyWASM } from 'dash-platform-sdk/types'
+import { Network, PrivateKeyWASM } from 'dash-platform-sdk/types'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { PrivateKey, decrypt } from 'eciesjs'
 import hash from 'hash.js'
@@ -91,7 +91,7 @@ export class RegisterIdentityHandler implements APIHandler {
       throw new Error('Failed to decrypt asset lock funding key — wrong password or corrupted entry')
     }
 
-    const assetLockFundingPrivateKey = PrivateKeyWASM.fromBytes(assetLockFundingKeyBytes, wallet.network)
+    const assetLockFundingPrivateKey = PrivateKeyWASM.fromBytes(assetLockFundingKeyBytes, wallet.network as Network)
 
     // ── 4. Find the next free identity index on-chain ───────────────────────
     // Used only for deriving identity keys (master/high/encryption/transfer).

--- a/src/content-script/api/private/stateTransitions/approveStateTransition.ts
+++ b/src/content-script/api/private/stateTransitions/approveStateTransition.ts
@@ -61,7 +61,6 @@ export class ApproveStateTransitionHandler implements APIHandler {
         if (stateTransitionWASM.getActionType() === 'DATA_CONTRACT_UPDATE') {
           const dataContractUpdateTransitionWASM = DataContractUpdateTransitionWASM.fromStateTransition(stateTransitionWASM)
 
-          // @ts-expect-error
           dataContractId = dataContractUpdateTransitionWASM.getDataContract().id
         }
 

--- a/src/content-script/repository/KeypairRepository.ts
+++ b/src/content-script/repository/KeypairRepository.ts
@@ -1,6 +1,6 @@
 import { StorageAdapter } from '../storage/storageAdapter'
 import { Identity, KeyPair, Wallet, WalletType } from '../../types'
-import { IdentityPublicKeyWASM, PrivateKeyWASM } from 'dash-platform-sdk/types'
+import { IdentityPublicKeyWASM, Network, PrivateKeyWASM } from 'dash-platform-sdk/types'
 import { KeyPairSchema, KeyPairsSchema } from '../storage/storageSchema'
 import { bytesToHex, deriveKeystorePrivateKey, deriveIdentityPrivateKey, hexToBytes } from '../../utils'
 import { encrypt } from 'eciesjs'
@@ -26,7 +26,7 @@ export class KeypairRepository {
     if (!pending) {
       const [identityPublicKey] = await this.sdk.identities.getIdentityPublicKeys(identity, [keyId])
 
-      if (PrivateKeyWASM.fromHex(privateKey, network).getPublicKeyHash() !== identityPublicKey.getPublicKeyHash()) {
+      if (PrivateKeyWASM.fromHex(privateKey, network as Network).getPublicKeyHash() !== identityPublicKey.getPublicKeyHash()) {
         throw new Error('Private key does not match Identity Public Key')
       }
     }

--- a/src/injected/ExtensionSigner.ts
+++ b/src/injected/ExtensionSigner.ts
@@ -69,8 +69,8 @@ export class ExtensionSigner {
       // Uint8Array (bytes)
     } else if (typeof stateTransition === 'object' && (stateTransition as Uint8Array) instanceof Uint8Array) {
       stateTransitionWASM = StateTransitionWASM.fromBytes(stateTransition as Uint8Array)
-    } else if (typeof stateTransition === 'object' && (stateTransition as StateTransitionWASM).__type === 'StateTransitionWASM') {
-      stateTransitionWASM = stateTransition as StateTransitionWASM
+    } else if (stateTransition instanceof StateTransitionWASM) {
+      stateTransitionWASM = stateTransition
     } else {
       throw new Error('Unrecognized state transition type, must be StateTransitionWASM or string hex or string base64 or Uint8Array')
     }

--- a/src/ui/components/settings/screens/CreateKeyScreen.tsx
+++ b/src/ui/components/settings/screens/CreateKeyScreen.tsx
@@ -117,8 +117,7 @@ export const CreateKeyScreen: React.FC<SettingsScreenProps> = ({
         signature = hexToBytes(createPrivateKeyResponse.signature)
       }
 
-      // KeyType is a const enum in SDK 1.4 — dynamic lookup `KeyType[name]` is
-      // forbidden by TS, so map the validated string value explicitly.
+      // Map explicitly — KeyType is a const enum, no dynamic `KeyType[name]` indexing.
       const keyTypeEnum: KeyType = keyType === 'ECDSA_SECP256K1'
         ? KeyType.ECDSA_SECP256K1
         : KeyType.ECDSA_HASH160

--- a/src/ui/components/settings/screens/CreateKeyScreen.tsx
+++ b/src/ui/components/settings/screens/CreateKeyScreen.tsx
@@ -117,7 +117,11 @@ export const CreateKeyScreen: React.FC<SettingsScreenProps> = ({
         signature = hexToBytes(createPrivateKeyResponse.signature)
       }
 
-      const keyTypeEnum = KeyType[keyType]
+      // KeyType is a const enum in SDK 1.4 — dynamic lookup `KeyType[name]` is
+      // forbidden by TS, so map the validated string value explicitly.
+      const keyTypeEnum: KeyType = keyType === 'ECDSA_SECP256K1'
+        ? KeyType.ECDSA_SECP256K1
+        : KeyType.ECDSA_HASH160
       const publicKeyToAdd = {
         id: createPrivateKeyResponse.keyId,
         keyType: keyTypeEnum,

--- a/src/ui/states/approveTransaction/ApproveTransactionState.tsx
+++ b/src/ui/states/approveTransaction/ApproveTransactionState.tsx
@@ -9,7 +9,7 @@ import { PasswordField } from '../../components/forms'
 import { FieldLabel } from '../../components/typography'
 import { TitleBlock } from '../../components/layout/TitleBlock'
 import { useExtensionAPI, useSigningKeys } from '../../hooks'
-import { StateTransitionWASM } from 'dash-platform-sdk/types'
+import { Purpose, StateTransitionWASM } from 'dash-platform-sdk/types'
 import { withAccessControl } from '../../components/auth/withAccessControl'
 import type { OutletContext } from '../../types'
 import LoadingScreen from '../../components/layout/LoadingScreen'
@@ -188,7 +188,7 @@ function ApproveTransactionState (): React.JSX.Element {
 
       if (Array.isArray(purposeRequirements)) {
         for (const purpose of purposeRequirements) {
-          const securityLevel = stateTransitionWASM.getKeyLevelRequirement(purpose)
+          const securityLevel = stateTransitionWASM.getKeyLevelRequirement(purpose as keyof typeof Purpose)
 
           if (Array.isArray(securityLevel)) {
             securityLevel.forEach(level => {

--- a/src/utils/decodeStateTransition.ts
+++ b/src/utils/decodeStateTransition.ts
@@ -6,7 +6,7 @@ import {
   MasternodeVoteTransitionWASM,
   DataContractUpdateTransitionWASM
 } from 'dash-platform-sdk/types'
-import { IdentityCreditWithdrawalTransitionWASM, DataContractCreateTransitionWASM, PlatformVersionWASM } from 'pshenmic-dpp'
+import { IdentityCreditWithdrawalTransitionWASM, DataContractCreateTransitionWASM, PlatformVersionWASM, DocumentTransitionWASM } from 'pshenmic-dpp'
 import { StateTransitionTypeEnum, DocumentActionEnum, TokenActionEnum } from '../enums'
 import { DecodedStateTransition } from '../types'
 
@@ -19,28 +19,10 @@ export const decodeStateTransition = (stateTransitionWASM: StateTransitionWASM):
 
       const transitions = batch.transitions.map((batchedTransition) => {
         const transition = batchedTransition.toTransition()
-        const transitionType = transition.__type === 'DocumentTransitionWASM' ? 0 : 1
 
         const out: any = {}
 
-        if (transitionType === 1) {
-          // Token transition
-          const tokenTransitionType = transition.getTransitionTypeNumber()
-          const tokenTransition = transition.getTransition()
-
-          out.action = TokenActionEnum[tokenTransitionType] ?? `TOKEN_${String(tokenTransitionType)}`
-          out.tokenId = tokenTransition.base.tokenId.base58()
-          out.identityContractNonce = String(transition.identityContractNonce)
-          out.dataContractId = tokenTransition.base.dataContractId.base58()
-
-          // Add specific fields based on token action type
-          if (tokenTransition.amount != null) {
-            out.amount = tokenTransition.amount.toString()
-          }
-          if (tokenTransition.recipientId != null) {
-            out.recipient = tokenTransition.recipientId.base58()
-          }
-        } else {
+        if (transition instanceof DocumentTransitionWASM) {
           // Document transition
           out.action = DocumentActionEnum[transition.actionTypeNumber] ?? `DOCUMENT_ACTION_${String(transition.actionTypeNumber)}`
           out.id = transition.id.base58()
@@ -89,6 +71,24 @@ export const decodeStateTransition = (stateTransitionWASM: StateTransitionWASM):
             }
           } catch (e) {
             console.log(e)
+          }
+        } else {
+          // Token transition
+          const tokenTransitionType = transition.getTransitionTypeNumber()
+          const tokenTransition = transition.getTransition()
+
+          out.action = TokenActionEnum[tokenTransitionType] ?? `TOKEN_${String(tokenTransitionType)}`
+          out.tokenId = tokenTransition.base.tokenId.base58()
+          out.identityContractNonce = String(transition.identityContractNonce)
+          out.dataContractId = tokenTransition.base.dataContractId.base58()
+
+          // Add specific fields based on token action type. The union doesn't
+          // declare amount/recipientId on every variant — narrow via `in`.
+          if ('amount' in tokenTransition && tokenTransition.amount != null) {
+            out.amount = tokenTransition.amount.toString()
+          }
+          if ('recipientId' in tokenTransition && tokenTransition.recipientId != null) {
+            out.recipient = tokenTransition.recipientId.base58()
           }
         }
 
@@ -233,7 +233,7 @@ export const decodeStateTransition = (stateTransitionWASM: StateTransitionWASM):
 
     case StateTransitionTypeEnum.DATA_CONTRACT_UPDATE: {
       const transition = DataContractUpdateTransitionWASM.fromStateTransition(stateTransitionWASM)
-      const dataContract = transition.getDataContract(null, PlatformVersionWASM.PLATFORM_V9)
+      const dataContract = transition.getDataContract(undefined, PlatformVersionWASM.PLATFORM_V9)
       const config = dataContract.getConfig()
       const groupsKeys = Object.keys(dataContract.groups ?? {})
       const signatureUpdate = stateTransitionWASM.signature

--- a/src/utils/identityRegistration.ts
+++ b/src/utils/identityRegistration.ts
@@ -1,17 +1,27 @@
 import type { DashPlatformSDK } from 'dash-platform-sdk'
-import { KeyType, Purpose, SecurityLevel, PrivateKeyWASM, StateTransitionWASM } from 'dash-platform-sdk/types'
+import { PrivateKeyWASM, StateTransitionWASM } from 'dash-platform-sdk/types'
 import type { AssetLockProof } from '../types/AssetLockProof'
 
+// Numeric literals instead of `Purpose.AUTHENTICATION` etc. because SDK 1.4
+// re-exports these as `const enum` — webpack inlines them at build time, but
+// ts-jest sees the imported binding as `undefined` at runtime. The literal
+// numbers ARE the const-enum values (Purpose.AUTHENTICATION = 0 etc.), so
+// assignability to the `Purpose | SecurityLevel | KeyType` field types holds.
+//
+// Purpose:        AUTHENTICATION = 0, ENCRYPTION = 1, DECRYPTION = 2, TRANSFER = 3
+// SecurityLevel:  MASTER = 0, CRITICAL = 1, HIGH = 2, MEDIUM = 3
+// KeyType:        ECDSA_SECP256K1 = 0
+//
 // Protocol limits IdentityCreateTransition to 6 public keys. AUTH MEDIUM is
 // dropped (used only for routine background transitions, can be added later
 // via IdentityUpdateTransition); MASTER/CRITICAL/HIGH cover the common path.
 export const IDENTITY_KEY_DEFINITIONS = [
-  { id: 0, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.MASTER, keyType: KeyType.ECDSA_SECP256K1 },
-  { id: 1, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1 },
-  { id: 2, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.HIGH, keyType: KeyType.ECDSA_SECP256K1 },
-  { id: 3, purpose: Purpose.ENCRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1 },
-  { id: 4, purpose: Purpose.DECRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1 },
-  { id: 5, purpose: Purpose.TRANSFER, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1 }
+  { id: 0, purpose: 0, securityLevel: 0, keyType: 0 }, // AUTH + MASTER
+  { id: 1, purpose: 0, securityLevel: 1, keyType: 0 }, // AUTH + CRITICAL
+  { id: 2, purpose: 0, securityLevel: 2, keyType: 0 }, // AUTH + HIGH
+  { id: 3, purpose: 1, securityLevel: 3, keyType: 0 }, // ENCRYPTION + MEDIUM
+  { id: 4, purpose: 2, securityLevel: 3, keyType: 0 }, // DECRYPTION + MEDIUM
+  { id: 5, purpose: 3, securityLevel: 1, keyType: 0 } // TRANSFER + CRITICAL
 ] as const
 
 /**
@@ -56,7 +66,7 @@ export const buildIdentityCreateTransition = (
     assetLockProof
   })
 
-  stateTransition.signByPrivateKey(identityRegistrationKey, undefined, KeyType.ECDSA_SECP256K1)
+  stateTransition.signByPrivateKey(identityRegistrationKey, undefined, 0) // ECDSA_SECP256K1
 
   return stateTransition
 }

--- a/src/utils/identityRegistration.ts
+++ b/src/utils/identityRegistration.ts
@@ -2,26 +2,22 @@ import type { DashPlatformSDK } from 'dash-platform-sdk'
 import { PrivateKeyWASM, StateTransitionWASM } from 'dash-platform-sdk/types'
 import type { AssetLockProof } from '../types/AssetLockProof'
 
-// Numeric literals instead of `Purpose.AUTHENTICATION` etc. because SDK 1.4
-// re-exports these as `const enum` — webpack inlines them at build time, but
-// ts-jest sees the imported binding as `undefined` at runtime. The literal
-// numbers ARE the const-enum values (Purpose.AUTHENTICATION = 0 etc.), so
-// assignability to the `Purpose | SecurityLevel | KeyType` field types holds.
-//
-// Purpose:        AUTHENTICATION = 0, ENCRYPTION = 1, DECRYPTION = 2, TRANSFER = 3
-// SecurityLevel:  MASTER = 0, CRITICAL = 1, HIGH = 2, MEDIUM = 3
-// KeyType:        ECDSA_SECP256K1 = 0
-//
+// SDK 1.4 exports Purpose/SecurityLevel/KeyType as `const enum`s, which ts-jest
+// erases to `undefined` at runtime — local numeric aliases keep them readable and runtime-safe.
+const Purpose = { AUTHENTICATION: 0, ENCRYPTION: 1, DECRYPTION: 2, TRANSFER: 3 } as const
+const SecurityLevel = { MASTER: 0, CRITICAL: 1, HIGH: 2, MEDIUM: 3 } as const
+const KeyType = { ECDSA_SECP256K1: 0 } as const
+
 // Protocol limits IdentityCreateTransition to 6 public keys. AUTH MEDIUM is
 // dropped (used only for routine background transitions, can be added later
 // via IdentityUpdateTransition); MASTER/CRITICAL/HIGH cover the common path.
 export const IDENTITY_KEY_DEFINITIONS = [
-  { id: 0, purpose: 0, securityLevel: 0, keyType: 0 }, // AUTH + MASTER
-  { id: 1, purpose: 0, securityLevel: 1, keyType: 0 }, // AUTH + CRITICAL
-  { id: 2, purpose: 0, securityLevel: 2, keyType: 0 }, // AUTH + HIGH
-  { id: 3, purpose: 1, securityLevel: 3, keyType: 0 }, // ENCRYPTION + MEDIUM
-  { id: 4, purpose: 2, securityLevel: 3, keyType: 0 }, // DECRYPTION + MEDIUM
-  { id: 5, purpose: 3, securityLevel: 1, keyType: 0 } // TRANSFER + CRITICAL
+  { id: 0, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.MASTER, keyType: KeyType.ECDSA_SECP256K1 },
+  { id: 1, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1 },
+  { id: 2, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.HIGH, keyType: KeyType.ECDSA_SECP256K1 },
+  { id: 3, purpose: Purpose.ENCRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1 },
+  { id: 4, purpose: Purpose.DECRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1 },
+  { id: 5, purpose: Purpose.TRANSFER, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1 }
 ] as const
 
 /**
@@ -66,7 +62,7 @@ export const buildIdentityCreateTransition = (
     assetLockProof
   })
 
-  stateTransition.signByPrivateKey(identityRegistrationKey, undefined, 0) // ECDSA_SECP256K1
+  stateTransition.signByPrivateKey(identityRegistrationKey, undefined, KeyType.ECDSA_SECP256K1)
 
   return stateTransition
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -91,7 +91,7 @@ export const deriveKeystorePrivateKey = async (wallet: Wallet, password: string,
     throw new Error('Failed to decrypt')
   }
 
-  return PrivateKeyWASM.fromBytes(privateKey, wallet.network)
+  return PrivateKeyWASM.fromBytes(privateKey, wallet.network as 'mainnet' | 'testnet')
 }
 
 export const decryptMnemonic = (wallet: Wallet, password: string): string => {
@@ -119,7 +119,7 @@ export const deriveIdentityRegistrationKey = async (wallet: Wallet, password: st
     throw new Error('Could not derive identity registration key from wallet hd key')
   }
 
-  return PrivateKeyWASM.fromBytes(privateKey, wallet.network)
+  return PrivateKeyWASM.fromBytes(privateKey, wallet.network as 'mainnet' | 'testnet')
 }
 
 export const deriveIdentityPrivateKey = async (wallet: Wallet, password: string, identityIndex: number, keyId: number, sdk: DashPlatformSDK): Promise<PrivateKeyWASM> => {
@@ -132,7 +132,7 @@ export const deriveIdentityPrivateKey = async (wallet: Wallet, password: string,
     throw new Error('Could not derive private key from wallet hd key')
   }
 
-  return PrivateKeyWASM.fromBytes(privateKey, wallet.network)
+  return PrivateKeyWASM.fromBytes(privateKey, wallet.network as 'mainnet' | 'testnet')
 }
 
 export const fetchIdentitiesBySeed = async (seed: Uint8Array, sdk: DashPlatformSDK, network: Network): Promise<IdentityWASM[]> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6978,10 +6978,10 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-pshenmic-dpp@2.0.0-dev.16:
-  version "2.0.0-dev.16"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.16.tgz#c1e58554c02cd764377e80cf464ba82a6fae483b"
-  integrity sha512-oCqdMUAsYNj23RiG2xC7Mz60kdnVWlyUlJ42NvhTPEeTmlotB/OCLsKpBLubGC/B6ge6z26kH66Ae4ShW/NniQ==
+pshenmic-dpp@2.0.0-dev.16, pshenmic-dpp@2.0.0-dev.17:
+  version "2.0.0-dev.17"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.17.tgz#bd385319724270f28915ebb30793597ee7e35ee8"
+  integrity sha512-zRweXH/+lZTbc2xy7R0qnLwMniE3yJihndGgHH3qWFhsUf88iQIKRwNm1DM0cdgiHf0gLVptaCr4BWKw+YsJ0w==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,14 @@
   resolved "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.4.tgz"
   integrity sha512-t+iX+Wf5nRKyNzk8dviW3Ikb/280+aEJAnw9YXvCp2tYGPSkMki+NRY+8aNLmVFv3eNtMdvViPNOPxS8SZNP+w==
 
+"@emnapi/core@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.0.tgz#4a54213b208fcf288cce25076c74e0f7613e6100"
+  integrity sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.0"
+    tslib "^2.4.0"
+
 "@emnapi/core@^1.5.0":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
@@ -1031,10 +1039,24 @@
     "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
+"@emnapi/runtime@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.0.tgz#91c54a6e77c36154c125e873409472e2b70efd5b"
+  integrity sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==
+  dependencies:
+    tslib "^2.4.0"
+
 "@emnapi/runtime@^1.5.0":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.2.tgz#8b469a3db160817cadb1de9050211a9d1ea84fa2"
   integrity sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
+  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
   dependencies:
     tslib "^2.4.0"
 
@@ -3767,10 +3789,10 @@ dash-core-sdk@1.1.3-dev.1:
     typescript "^5.9.2"
     ws "^8.18.3"
 
-dash-platform-sdk@1.3.2-dev.3:
-  version "1.3.2-dev.3"
-  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.3.2-dev.3.tgz#7406cb4b93b3c80aa0f99e4627749e40728ea046"
-  integrity sha512-m1waDIgb+xoTqTIsES9/3tshwv6y3zaRdBYg3R8CLekCZJlOxFkSzk45ekaoEPVfWrG8tES4zlFZ+Q+gdKaQWA==
+dash-platform-sdk@1.4.0-dev.11:
+  version "1.4.0-dev.11"
+  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.4.0-dev.11.tgz#bd31332073f4720a61278a6e57dea9aba5673776"
+  integrity sha512-NF4F0DcM9Vl7sVtU7a1q/+YZ4yZ6UG12FIPF8uJJYySnr8FbrStF4F6etOnX9H8TsiSkKGLjdpfCO8hTPIzHMw==
   dependencies:
     "@bufbuild/protobuf" "^2.6.0"
     "@protobuf-ts/grpcweb-transport" "^2.11.1"
@@ -3779,7 +3801,7 @@ dash-platform-sdk@1.3.2-dev.3:
     "@scure/bip39" "^2.0.0"
     "@scure/btc-signer" "^2.0.1"
     cbor-x "^1.6.0"
-    pshenmic-dpp "1.1.2-dev.10"
+    pshenmic-dpp "2.0.0-dev.16"
 
 dash-ui-kit@2.1.2:
   version "2.1.2"
@@ -6956,11 +6978,14 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-pshenmic-dpp@1.1.2-dev.10:
-  version "1.1.2-dev.10"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-1.1.2-dev.10.tgz#3abc4ba0f31ac48fafe23bd6f34f2b864daa5eb3"
-  integrity sha512-2S1eF5UjhOrEJ5cLn2YBk2k/TNDFipO2cLDHbpMGOhy//NcoFIPIZfo2l6n01dA0fCOLDpjHa/1smrVABUAGkg==
+pshenmic-dpp@2.0.0-dev.16:
+  version "2.0.0-dev.16"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.16.tgz#c1e58554c02cd764377e80cf464ba82a6fae483b"
+  integrity sha512-oCqdMUAsYNj23RiG2xC7Mz60kdnVWlyUlJ42NvhTPEeTmlotB/OCLsKpBLubGC/B6ge6z26kH66Ae4ShW/NniQ==
   dependencies:
+    "@emnapi/core" "1.9.0"
+    "@emnapi/runtime" "1.9.0"
+    "@tybys/wasm-util" "^0.10.1"
     fflate "^0.8.2"
 
 punycode@^2.1.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,10 +3789,10 @@ dash-core-sdk@1.1.3-dev.1:
     typescript "^5.9.2"
     ws "^8.18.3"
 
-dash-platform-sdk@1.4.0-dev.11:
-  version "1.4.0-dev.11"
-  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.4.0-dev.11.tgz#bd31332073f4720a61278a6e57dea9aba5673776"
-  integrity sha512-NF4F0DcM9Vl7sVtU7a1q/+YZ4yZ6UG12FIPF8uJJYySnr8FbrStF4F6etOnX9H8TsiSkKGLjdpfCO8hTPIzHMw==
+dash-platform-sdk@1.4.0-dev.13:
+  version "1.4.0-dev.13"
+  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.4.0-dev.13.tgz#22ba416d18473b9ee47560d9ce216ee0f04407c1"
+  integrity sha512-dAVIhjlUaxUjAbVmdER/hDw1AgVlYEFgc56y42dDrb28vdG5tU4LpEE6L4AitBz/u2i9BtLN5Nxi7NYSkaqQ4Q==
   dependencies:
     "@bufbuild/protobuf" "^2.6.0"
     "@protobuf-ts/grpcweb-transport" "^2.11.1"
@@ -3801,7 +3801,7 @@ dash-platform-sdk@1.4.0-dev.11:
     "@scure/bip39" "^2.0.0"
     "@scure/btc-signer" "^2.0.1"
     cbor-x "^1.6.0"
-    pshenmic-dpp "2.0.0-dev.16"
+    pshenmic-dpp "2.0.0-dev.18"
 
 dash-ui-kit@2.1.2:
   version "2.1.2"
@@ -6978,10 +6978,10 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-pshenmic-dpp@2.0.0-dev.16, pshenmic-dpp@2.0.0-dev.17:
-  version "2.0.0-dev.17"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.17.tgz#bd385319724270f28915ebb30793597ee7e35ee8"
-  integrity sha512-zRweXH/+lZTbc2xy7R0qnLwMniE3yJihndGgHH3qWFhsUf88iQIKRwNm1DM0cdgiHf0gLVptaCr4BWKw+YsJ0w==
+pshenmic-dpp@2.0.0-dev.18:
+  version "2.0.0-dev.18"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.18.tgz#3bd59871c823c4055a08c936d0534deb9eec70d3"
+  integrity sha512-YwXdQarhJr7USCn1lC80TQongr2mmlr3MObukFPUr9b0/yYDAzLD3AZXzbhM8KhgT+uyJVrqT/bRAbXN0gUOGA==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"


### PR DESCRIPTION
## Why

The `pshenmic-dpp` v2 wrapper API (`TokenConfigurationWASM`, `DataContractWASM` with embedded tokens, etc.) is required to decode and sign `DataContractCreate` state transitions that include token configurations introduced in Dash Platform v2.0.

The extension previously pinned `dash-platform-sdk@1.3.2-dev.3`, which transitively pulled `pshenmic-dpp@1.1.x` — no token wrapper API, so token-bearing state transitions were silently dropped or rejected in the approval popup.

Bumping `dash-platform-sdk` to `1.4.0-dev.13` brings `pshenmic-dpp@2.0.0-dev.18` transitively — the token-capable v2 API, with the latest fixes (incl. the token-distribution serde fix).

## Companion frontend PR

[pshenmic/platform-explorer#795](https://github.com/pshenmic/platform-explorer/pull/795) adds the `/tokens/create` UI. With this extension loaded unpacked, the Extension signer flow is **verified end-to-end on testnet**: the approval popup decodes the contract + token configuration (id, name, base supply, decimals), and `signAndBroadcast` writes the token to chain. The frontend's `useSigner` hands a base64-encoded state transition across the wasm boundary, so this PR's bundled v2 dpp is what parses the bytes on the extension side.

## Changes

### Dependency bump (`chore (deps): bump sdk to dev.13, drop pshenmic-dpp resolution`)
- `package.json` — `dash-platform-sdk: 1.3.2-dev.3` → `1.4.0-dev.13`
- `yarn.lock` — regenerated
- **No `resolutions` override needed** — `1.4.0-dev.13` natively pins `pshenmic-dpp@2.0.0-dev.18`. (An earlier interim revision force-pinned `dev.17` via yarn `resolutions` to dodge a webpack packaging bug; that block has been dropped now that the SDK pins a good version itself.)

### SDK 1.4 type migration
SDK 1.4 tightened types and introduced `const enum`s, breaking several call sites:
- `as Network` casts at `PrivateKeyWASM.fromHex/fromBytes` call sites; `Network` imported from `dash-platform-sdk/types` where missing.
- `KeyType[stringName]` dynamic enum access is forbidden on `const enum`s — replaced with explicit ternaries (`createIdentityPrivateKey.ts`, `CreateKeyScreen.tsx`).
- `identityRegistration.ts` — `Purpose`/`SecurityLevel`/`KeyType` const-enum members are erased at runtime under ts-jest; replaced with small local numeric-aliased constants so the key definitions stay readable and runtime-safe.
- `decodeStateTransition.ts` — dropped the removed `__type === 'DocumentTransitionWASM'` discriminator for `instanceof DocumentTransitionWASM`; `in`-operator narrowing for `amount`/`recipientId` on the token-transition union; `null` → `undefined` on `getDataContract`.
- `ExtensionSigner.ts` — `__type === 'StateTransitionWASM'` → `instanceof StateTransitionWASM`.
- `approveStateTransition.ts` — removed obsolete `@ts-expect-error`.
- `ApproveTransactionState.tsx` — `getKeyLevelRequirement(purpose)` cast via `keyof typeof Purpose`.

## Test plan
- [x] `yarn install` clean, lock regenerated
- [x] `yarn build` exits 0 — no TS errors, no webpack errors
- [x] Load `dist/` as unpacked in Chrome
- [x] Extension flow on [#795](https://github.com/pshenmic/platform-explorer/pull/795) `/tokens/create`: Connect → Deploy → approval popup → approve → token on chain (testnet)
- [ ] Existing approval flows (DataContractUpdate, IdentityUpdate, Batch document transitions) still work — no regression (please review)

## Related extension issues
- #133 — cached rejected state blocks subsequent attempts (not addressed by this PR)
- #134 — request standalone `signer.sign()` API (not addressed by this PR)
