### PR TITLE
feat: background job core for long-running operations (SW/offscreen groundwork)

### DIFF
--- a/src/content-script/api/JobExecutor.ts
+++ b/src/content-script/api/JobExecutor.ts
@@ -1,0 +1,85 @@
+import { EventData } from '../../types'
+import { JobsRepository } from '../repository/JobsRepository'
+import { LongRunningHandler } from './LongRunningHandler'
+import { BroadcastError } from '../errors/BroadcastError'
+import { JobStatus } from '../../types/enums/JobStatus'
+
+// Context-agnostic controller for background (long-running) jobs. Given a method
+// + payload it creates a job record, runs the matching handler while streaming
+// its progress stages into the JobsRepository, and maps the terminal outcome
+// (success / failure) back into storage.
+//
+// It knows nothing about Chrome APIs: the service worker / offscreen entrypoints
+// are thin adapters that construct it with real repositories and handlers and
+// call runJob(). This keeps the whole job lifecycle — including "survives the
+// popup closing" — unit-testable without a browser.
+export class JobExecutor {
+  jobsRepository: JobsRepository
+  handlers: { [method: string]: LongRunningHandler }
+
+  constructor (jobsRepository: JobsRepository, handlers: { [method: string]: LongRunningHandler }) {
+    this.jobsRepository = jobsRepository
+    this.handlers = handlers
+  }
+
+  // Runs a job to completion, persisting progress and outcome. Resolves once the
+  // job reaches a terminal state; it never rejects — failures are recorded on the
+  // job so a closed popup can read them later. `event.id` is the job id (the
+  // popup generates it and watches storage for that id).
+  async runJob (event: EventData): Promise<void> {
+    const { id, method, payload } = event
+
+    await this.jobsRepository.create(id, method)
+
+    const handler = this.handlers[method]
+
+    if (handler == null) {
+      await this.jobsRepository.markFailed(id, { message: `Could not find handler for method ${method}` })
+      return
+    }
+
+    const validation = handler.validatePayload(payload)
+
+    if (validation != null) {
+      await this.jobsRepository.markFailed(id, { message: `Invalid payload: ${validation}` })
+      return
+    }
+
+    try {
+      const result = await handler.handle(event, {
+        onProgress: async (stage: string) => {
+          await this.jobsRepository.setStage(id, stage)
+        }
+      })
+
+      await this.jobsRepository.markSucceeded(id, result)
+    } catch (e) {
+      await this.jobsRepository.markFailed(id, this.toJobError(e))
+    }
+  }
+
+  // Reconciliation after a service-worker / offscreen restart: any job left in a
+  // non-terminal state (pending / running) had its executor torn down mid-flight
+  // and cannot resume, so mark it interrupted for the user to retry.
+  async reconcileInterrupted (): Promise<void> {
+    const jobs = await this.jobsRepository.getAll()
+
+    for (const job of jobs) {
+      if (job.status === JobStatus.pending || job.status === JobStatus.running) {
+        await this.jobsRepository.markInterrupted(job.id)
+      }
+    }
+  }
+
+  private toJobError (e: unknown): { message: string, signedHex?: string } {
+    if (e instanceof BroadcastError) {
+      return { message: e.message, signedHex: e.signedHex }
+    }
+
+    if (e instanceof Error) {
+      return { message: e.message }
+    }
+
+    return { message: String(e) }
+  }
+}

--- a/src/content-script/api/LongRunningHandler.ts
+++ b/src/content-script/api/LongRunningHandler.ts
@@ -1,0 +1,18 @@
+import { EventData } from '../../types'
+import { APIHandler } from './APIHandler'
+
+// Callback the job executor passes into a long-running handler so it can report
+// progress. The executor persists each reported stage (e.g. via JobsRepository)
+// so the popup can render it and it survives the popup closing.
+export interface JobProgressContext {
+  onProgress: (stage: string) => void | Promise<void>
+}
+
+// A handler for an operation that can outlive the popup: asset-lock waits,
+// Halo2 proving, state-transition confirmation. Identical to APIHandler except
+// `handle` accepts an optional progress context. When it is omitted the handler
+// behaves exactly like a plain APIHandler (the synchronous in-popup path, no
+// reporting), so the same handler works on both transports.
+export interface LongRunningHandler extends APIHandler {
+  handle: (event: EventData, ctx?: JobProgressContext) => Promise<any>
+}

--- a/src/content-script/api/private/identities/registerIdentity.ts
+++ b/src/content-script/api/private/identities/registerIdentity.ts
@@ -4,7 +4,7 @@ import { DashPlatformSDK } from 'dash-platform-sdk'
 import { PrivateKey, decrypt } from 'eciesjs'
 import hash from 'hash.js'
 import { EventData } from '../../../../types'
-import { APIHandler } from '../../APIHandler'
+import { JobProgressContext, LongRunningHandler } from '../../LongRunningHandler'
 import { WalletRepository } from '../../../repository/WalletRepository'
 import { IdentitiesRepository } from '../../../repository/IdentitiesRepository'
 import { AssetLockFundingAddressesRepository } from '../../../repository/AssetLockFundingAddressesRepository'
@@ -27,7 +27,19 @@ import { isIdentityNotFoundError } from '../../../../utils/isIdentityNotFoundErr
 import { WalletType } from '../../../../types/WalletType'
 import { TXID_HEX_LENGTH, IDENTITY_INDEX_SCAN_LIMIT, REGISTRATION_CONFIRM_TIMEOUT_MS } from '../../../../constants'
 
-export class RegisterIdentityHandler implements APIHandler {
+// Progress stages reported through JobProgressContext, in execution order. The
+// popup renders these while the job runs in the background; a job may skip
+// `broadcastingAssetLock` when recovering an already-broadcast asset lock.
+export const REGISTER_IDENTITY_STAGES = {
+  preparing: 'preparing',
+  buildingAssetLock: 'building-asset-lock',
+  broadcastingAssetLock: 'broadcasting-asset-lock',
+  waitingAssetLockProof: 'waiting-asset-lock-proof',
+  broadcastingStateTransition: 'broadcasting-state-transition',
+  confirming: 'confirming'
+} as const
+
+export class RegisterIdentityHandler implements LongRunningHandler {
   walletRepository: WalletRepository
   identitiesRepository: IdentitiesRepository
   assetLockFundingAddressesRepository: AssetLockFundingAddressesRepository
@@ -51,8 +63,16 @@ export class RegisterIdentityHandler implements APIHandler {
     this.coreSDK = coreSDK
   }
 
-  async handle (event: EventData): Promise<RegisterIdentityResponse> {
+  async handle (event: EventData, ctx?: JobProgressContext): Promise<RegisterIdentityResponse> {
     const payload: RegisterIdentityPayload = event.payload
+
+    const reportStage = async (stage: string): Promise<void> => {
+      if (ctx?.onProgress != null) {
+        await ctx.onProgress(stage)
+      }
+    }
+
+    await reportStage(REGISTER_IDENTITY_STAGES.preparing)
 
     // ── 1. Validate wallet and network context ──────────────────────────────
     const wallet = await this.walletRepository.getCurrent()
@@ -135,6 +155,8 @@ export class RegisterIdentityHandler implements APIHandler {
     // ── 6. Build asset lock transaction ─────────────────────────────────────
     // Inputs are signed by the one-time funding key. Credit output goes to
     // creditOutputAddress (registration key). Build is deterministic on retry.
+    await reportStage(REGISTER_IDENTITY_STAGES.buildingAssetLock)
+
     const { assetLockTx } = await buildAssetLockFromFundingTx(
       this.coreSDK,
       payload.assetLockFundingTxid,
@@ -165,6 +187,7 @@ export class RegisterIdentityHandler implements APIHandler {
     )
 
     if (assetLockFundingAddressEntry.assetLockTxid == null) {
+      await reportStage(REGISTER_IDENTITY_STAGES.broadcastingAssetLock)
       await this.coreSDK.broadcastTransaction(assetLockTx.bytes())
       // Persist the broadcasted txid before any further work so a crash leaves
       // a recoverable record of the L1-committed asset lock.
@@ -172,6 +195,8 @@ export class RegisterIdentityHandler implements APIHandler {
     }
 
     // ── 8. Wait for instant lock or chain lock (whichever comes first) ──────
+    await reportStage(REGISTER_IDENTITY_STAGES.waitingAssetLockProof)
+
     const assetLockProof = await waitForAssetLockProof(
       this.coreSDK,
       this.sdk,
@@ -224,6 +249,8 @@ export class RegisterIdentityHandler implements APIHandler {
     // ── 13. Broadcast the state transition ──────────────────────────────────
     let alreadyOnPlatform = false
 
+    await reportStage(REGISTER_IDENTITY_STAGES.broadcastingStateTransition)
+
     try {
       await this.sdk.stateTransitions.broadcast(stateTransition)
     } catch (e) {
@@ -242,6 +269,8 @@ export class RegisterIdentityHandler implements APIHandler {
     // return once it exists rather than blocking indefinitely if the confirmation
     // stream is slow. A genuine state-transition failure still rolls back.
     if (!alreadyOnPlatform) {
+      await reportStage(REGISTER_IDENTITY_STAGES.confirming)
+
       try {
         await Promise.race([
           this.sdk.stateTransitions.waitForStateTransitionResult(stateTransition),

--- a/src/content-script/api/private/wallet/shieldToPool.ts
+++ b/src/content-script/api/private/wallet/shieldToPool.ts
@@ -1,5 +1,5 @@
 import { EventData } from '../../../../types/EventData'
-import { APIHandler } from '../../APIHandler'
+import { JobProgressContext, LongRunningHandler } from '../../LongRunningHandler'
 import { WalletRepository } from '../../../repository/WalletRepository'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { InputAddressWASM, AddressFundsFeeStrategyStepWASM } from 'pshenmic-dpp'
@@ -12,7 +12,18 @@ import { ShieldToPoolResponse } from '../../../../types/messages/response/Shield
 // largest covering amount + fee), signs the input with its key, and builds the
 // Orchard (Halo2) proof — slow, runs in the popup for now — targeting the wallet's
 // own shielded address. Needs the password.
-export class ShieldToPoolHandler implements APIHandler {
+
+// Progress stages reported through JobProgressContext, in execution order. The
+// `proving` stage covers the CPU-heavy Halo2 proof build — the reason shielded
+// operations must run in a context that outlives the popup.
+export const SHIELD_TO_POOL_STAGES = {
+  preparing: 'preparing',
+  proving: 'proving',
+  broadcasting: 'broadcasting',
+  confirming: 'confirming'
+} as const
+
+export class ShieldToPoolHandler implements LongRunningHandler {
   walletRepository: WalletRepository
   sdk: DashPlatformSDK
 
@@ -21,8 +32,17 @@ export class ShieldToPoolHandler implements APIHandler {
     this.sdk = sdk
   }
 
-  async handle (event: EventData): Promise<ShieldToPoolResponse> {
+  async handle (event: EventData, ctx?: JobProgressContext): Promise<ShieldToPoolResponse> {
     const payload: ShieldToPoolPayload = event.payload
+
+    const reportStage = async (stage: string): Promise<void> => {
+      if (ctx?.onProgress != null) {
+        await ctx.onProgress(stage)
+      }
+    }
+
+    await reportStage(SHIELD_TO_POOL_STAGES.preparing)
+
     const wallet = await this.walletRepository.getCurrent()
 
     if (wallet == null) {
@@ -57,6 +77,8 @@ export class ShieldToPoolHandler implements APIHandler {
     const inputs = [new InputAddressWASM(source.platformAddress, source.nonce + 1, source.balanceCredits)]
     const feeStrategy = [AddressFundsFeeStrategyStepWASM.DeductFromInput(0)]
 
+    await reportStage(SHIELD_TO_POOL_STAGES.proving)
+
     console.time('[shielded] shield: build + prove')
     const stateTransition = await this.sdk.shielded.createStateTransition('shield', {
       recipient,
@@ -70,8 +92,11 @@ export class ShieldToPoolHandler implements APIHandler {
     })
     console.timeEnd('[shielded] shield: build + prove')
 
+    await reportStage(SHIELD_TO_POOL_STAGES.broadcasting)
     console.log('[shielded] broadcasting…')
     await this.sdk.stateTransitions.broadcast(stateTransition)
+
+    await reportStage(SHIELD_TO_POOL_STAGES.confirming)
     await this.sdk.stateTransitions.waitForStateTransitionResult(stateTransition)
 
     return {

--- a/src/content-script/repository/JobsRepository.spec.ts
+++ b/src/content-script/repository/JobsRepository.spec.ts
@@ -1,0 +1,130 @@
+import { JobsRepository } from './JobsRepository'
+import { MemoryStorageAdapter } from '../storage/memoryStorageAdapter'
+import { JobStatus } from '../../types/enums/JobStatus'
+
+const NETWORK = 'testnet'
+const WALLET_ID = 'wallet-under-test'
+const STORAGE_KEY = `jobs_${NETWORK}_${WALLET_ID}`
+
+describe('JobsRepository', () => {
+  let storage: MemoryStorageAdapter
+  let repository: JobsRepository
+
+  beforeEach(async () => {
+    storage = new MemoryStorageAdapter()
+    // MemoryStorageAdapter keeps a shared module-level cache; reset the keys this
+    // suite touches so tests do not leak state into each other.
+    await storage.remove(STORAGE_KEY)
+    await storage.set('network', NETWORK)
+    await storage.set('currentWalletId', WALLET_ID)
+
+    repository = new JobsRepository(storage)
+  })
+
+  it('creates a pending job with timestamps and no stage', async () => {
+    const job = await repository.create('job-1', 'REGISTER_IDENTITY')
+
+    expect(job.id).toBe('job-1')
+    expect(job.method).toBe('REGISTER_IDENTITY')
+    expect(job.status).toBe(JobStatus.pending)
+    expect(job.stage).toBeNull()
+    expect(job.result).toBeNull()
+    expect(job.error).toBeNull()
+    expect(job.createdAt).toBeGreaterThan(0)
+    expect(job.updatedAt).toBe(job.createdAt)
+  })
+
+  it('rejects creating a job with a duplicate id', async () => {
+    await repository.create('job-1', 'REGISTER_IDENTITY')
+
+    await expect(repository.create('job-1', 'TOP_UP_IDENTITY'))
+      .rejects.toThrow('Job with id job-1 already exists')
+  })
+
+  it('returns null for an unknown job', async () => {
+    expect(await repository.getById('missing')).toBeNull()
+  })
+
+  it('persists the job so it is readable by a fresh repository instance', async () => {
+    await repository.create('job-1', 'SHIELD_TO_POOL')
+
+    const reopened = new JobsRepository(storage)
+    const job = await reopened.getById('job-1')
+
+    expect(job?.method).toBe('SHIELD_TO_POOL')
+    expect(job?.status).toBe(JobStatus.pending)
+  })
+
+  it('lists all jobs', async () => {
+    await repository.create('job-1', 'REGISTER_IDENTITY')
+    await repository.create('job-2', 'SHIELD_TO_POOL')
+
+    const all = await repository.getAll()
+
+    expect(all.map((job) => job.id).sort()).toEqual(['job-1', 'job-2'])
+  })
+
+  it('moves a job to running and records the stage', async () => {
+    const created = await repository.create('job-1', 'REGISTER_IDENTITY')
+
+    const running = await repository.setStage('job-1', 'waiting-asset-lock-proof')
+
+    expect(running.status).toBe(JobStatus.running)
+    expect(running.stage).toBe('waiting-asset-lock-proof')
+    expect(running.updatedAt).toBeGreaterThanOrEqual(created.updatedAt)
+  })
+
+  it('records a successful result', async () => {
+    await repository.create('job-1', 'REGISTER_IDENTITY')
+
+    const succeeded = await repository.markSucceeded('job-1', { identifier: 'abc' })
+
+    expect(succeeded.status).toBe(JobStatus.succeeded)
+    expect(succeeded.result).toEqual({ identifier: 'abc' })
+    expect(succeeded.error).toBeNull()
+  })
+
+  it('records a failure and preserves signedHex for re-broadcast', async () => {
+    await repository.create('job-1', 'SEND_PLATFORM_TRANSFER')
+
+    const failed = await repository.markFailed('job-1', {
+      message: 'Broadcast failed',
+      signedHex: 'deadbeef'
+    })
+
+    expect(failed.status).toBe(JobStatus.failed)
+    expect(failed.error).toEqual({ message: 'Broadcast failed', signedHex: 'deadbeef' })
+  })
+
+  it('marks a job interrupted when its executor is torn down', async () => {
+    await repository.create('job-1', 'SHIELD_TO_POOL')
+    await repository.setStage('job-1', 'proving')
+
+    const interrupted = await repository.markInterrupted('job-1')
+
+    expect(interrupted.status).toBe(JobStatus.interrupted)
+    // Stage is kept so the popup can tell the user where it stopped.
+    expect(interrupted.stage).toBe('proving')
+  })
+
+  it('throws when patching a non-existent job', async () => {
+    await expect(repository.setStage('missing', 'proving'))
+      .rejects.toThrow('Job with id missing does not exist')
+  })
+
+  it('removes a job and is idempotent on a missing id', async () => {
+    await repository.create('job-1', 'REGISTER_IDENTITY')
+
+    await repository.remove('job-1')
+    expect(await repository.getById('job-1')).toBeNull()
+
+    await expect(repository.remove('job-1')).resolves.toBeUndefined()
+  })
+
+  it('throws when no wallet is chosen', async () => {
+    await storage.remove('currentWalletId')
+
+    await expect(repository.create('job-1', 'REGISTER_IDENTITY'))
+      .rejects.toThrow('Wallet is not chosen')
+  })
+})

--- a/src/content-script/repository/JobsRepository.ts
+++ b/src/content-script/repository/JobsRepository.ts
@@ -1,0 +1,115 @@
+import { StorageAdapter } from '../storage/storageAdapter'
+import { JobStoreSchema, JobsStoreSchema } from '../storage/storageSchema'
+import { JobStatus } from '../../types/enums/JobStatus'
+
+// Pure storage for background job records. No orchestration, no network — the
+// service worker / offscreen executor owns the flow and calls into here only to
+// persist state transitions of a job.
+export class JobsRepository {
+  storageAdapter: StorageAdapter
+
+  constructor (storageAdapter: StorageAdapter) {
+    this.storageAdapter = storageAdapter
+  }
+
+  async create (id: string, method: string): Promise<JobStoreSchema> {
+    const storageKey = await this.getStorageKey()
+    const jobs = (await this.storageAdapter.get(storageKey) ?? {}) as JobsStoreSchema
+
+    if (jobs[id] != null) {
+      throw new Error(`Job with id ${id} already exists`)
+    }
+
+    const now = Date.now()
+
+    const job: JobStoreSchema = {
+      id,
+      method,
+      status: JobStatus.pending,
+      stage: null,
+      result: null,
+      error: null,
+      createdAt: now,
+      updatedAt: now
+    }
+
+    jobs[id] = job
+
+    await this.storageAdapter.set(storageKey, jobs)
+
+    return job
+  }
+
+  async getById (id: string): Promise<JobStoreSchema | null> {
+    const storageKey = await this.getStorageKey()
+    const jobs = (await this.storageAdapter.get(storageKey) ?? {}) as JobsStoreSchema
+
+    return jobs[id] ?? null
+  }
+
+  async getAll (): Promise<JobStoreSchema[]> {
+    const storageKey = await this.getStorageKey()
+    const jobs = (await this.storageAdapter.get(storageKey) ?? {}) as JobsStoreSchema
+
+    return Object.values(jobs)
+  }
+
+  async setStage (id: string, stage: string): Promise<JobStoreSchema> {
+    return await this.patch(id, { status: JobStatus.running, stage })
+  }
+
+  async markSucceeded (id: string, result: unknown): Promise<JobStoreSchema> {
+    return await this.patch(id, { status: JobStatus.succeeded, result })
+  }
+
+  async markFailed (id: string, error: { message: string, signedHex?: string }): Promise<JobStoreSchema> {
+    return await this.patch(id, { status: JobStatus.failed, error })
+  }
+
+  async markInterrupted (id: string): Promise<JobStoreSchema> {
+    return await this.patch(id, { status: JobStatus.interrupted })
+  }
+
+  async remove (id: string): Promise<void> {
+    const storageKey = await this.getStorageKey()
+    const jobs = (await this.storageAdapter.get(storageKey) ?? {}) as JobsStoreSchema
+
+    if (jobs[id] == null) {
+      return
+    }
+
+    const { [id]: _removed, ...rest } = jobs
+
+    await this.storageAdapter.set(storageKey, rest)
+  }
+
+  private async patch (id: string, changes: Partial<JobStoreSchema>): Promise<JobStoreSchema> {
+    const storageKey = await this.getStorageKey()
+    const jobs = (await this.storageAdapter.get(storageKey) ?? {}) as JobsStoreSchema
+
+    const job = jobs[id]
+
+    if (job == null) {
+      throw new Error(`Job with id ${id} does not exist`)
+    }
+
+    const updated: JobStoreSchema = { ...job, ...changes, updatedAt: Date.now() }
+
+    jobs[id] = updated
+
+    await this.storageAdapter.set(storageKey, jobs)
+
+    return updated
+  }
+
+  private async getStorageKey (): Promise<string> {
+    const network = await this.storageAdapter.get('network') as string
+    const walletId = await this.storageAdapter.get('currentWalletId') as string | null
+
+    if (walletId == null) {
+      throw new Error('Wallet is not chosen')
+    }
+
+    return `jobs_${network}_${walletId}`
+  }
+}

--- a/src/content-script/storage/storageSchema.ts
+++ b/src/content-script/storage/storageSchema.ts
@@ -86,3 +86,29 @@ export interface AssetLockFundingAddressesSchema {
 export interface WalletSettingsStoreSchema {
   hideBalance: boolean
 }
+
+// Persisted record of a long-running background operation (identity
+// registration, top-up, platform / shielded state transitions). Written by the
+// offscreen executor so it survives the popup closing; the popup reads it back
+// (directly or via chrome.storage.onChanged) to render progress and outcome.
+export interface JobStoreSchema {
+  id: string
+  // MessagingMethods value the job executes.
+  method: string
+  // JobStatus value.
+  status: string
+  // Current step within a running job (e.g. 'waiting-asset-lock-proof',
+  // 'proving'); null until the executor reports the first stage.
+  stage: string | null
+  // Terminal success payload — the same shape the handler returns synchronously.
+  result: unknown | null
+  // Terminal failure detail. `signedHex` preserves BroadcastError context so the
+  // popup can offer a re-broadcast, mirroring the current messaging error path.
+  error: { message: string, signedHex?: string } | null
+  createdAt: number
+  updatedAt: number
+}
+
+export interface JobsStoreSchema {
+  [id: string]: JobStoreSchema
+}

--- a/src/types/enums/JobStatus.ts
+++ b/src/types/enums/JobStatus.ts
@@ -1,0 +1,11 @@
+export enum JobStatus {
+  // Job created, accepted by the service worker, not yet picked up by offscreen.
+  pending = 'pending',
+  // Offscreen is executing the job; `stage` carries the current step.
+  running = 'running',
+  succeeded = 'succeeded',
+  failed = 'failed',
+  // The executing context (offscreen / service worker) was torn down mid-flight
+  // before reaching a terminal state. The user must retry.
+  interrupted = 'interrupted',
+}

--- a/test/api/JobExecutor.spec.ts
+++ b/test/api/JobExecutor.spec.ts
@@ -1,0 +1,185 @@
+import { JobExecutor } from '../../src/content-script/api/JobExecutor'
+import { JobsRepository } from '../../src/content-script/repository/JobsRepository'
+import { MemoryStorageAdapter } from '../../src/content-script/storage/memoryStorageAdapter'
+import { BroadcastError } from '../../src/content-script/errors/BroadcastError'
+import { JobStatus } from '../../src/types/enums/JobStatus'
+import { EventData } from '../../src/types'
+
+const NETWORK = 'testnet'
+const WALLET_ID = 'wallet-under-test'
+const STORAGE_KEY = `jobs_${NETWORK}_${WALLET_ID}`
+
+const event = (id: string, method: string, payload: any = {}): EventData => ({
+  context: 'dash-platform-extension',
+  id,
+  method,
+  type: 'request',
+  payload
+})
+
+// Resolves the returned promise from the outside — lets a test hold a handler
+// mid-flight (simulating a long asset-lock wait) and release it on demand.
+const deferred = (): { promise: Promise<void>, resolve: () => void } => {
+  let resolveFn!: () => void
+  const promise = new Promise<void>((resolve) => { resolveFn = resolve })
+  return { promise, resolve: resolveFn }
+}
+
+describe('JobExecutor', () => {
+  let storage: MemoryStorageAdapter
+  let jobsRepository: JobsRepository
+
+  beforeEach(async () => {
+    storage = new MemoryStorageAdapter()
+    await storage.remove(STORAGE_KEY)
+    await storage.set('network', NETWORK)
+    await storage.set('currentWalletId', WALLET_ID)
+
+    jobsRepository = new JobsRepository(storage)
+  })
+
+  test('runs a handler to success and records the result', async () => {
+    const handler = {
+      validatePayload: jest.fn(() => null),
+      handle: jest.fn(async () => ({ identifier: 'abc' }))
+    }
+
+    const executor = new JobExecutor(jobsRepository, { REGISTER_IDENTITY: handler })
+    await executor.runJob(event('job-1', 'REGISTER_IDENTITY'))
+
+    const job = await jobsRepository.getById('job-1')
+    expect(job?.status).toBe(JobStatus.succeeded)
+    expect(job?.result).toEqual({ identifier: 'abc' })
+    expect(job?.error).toBeNull()
+  })
+
+  test('streams handler progress stages into the job record', async () => {
+    const setStageSpy = jest.spyOn(jobsRepository, 'setStage')
+
+    const handler = {
+      validatePayload: jest.fn(() => null),
+      handle: jest.fn(async (_event: EventData, ctx?: any) => {
+        await ctx.onProgress('building-asset-lock')
+        await ctx.onProgress('waiting-asset-lock-proof')
+        return { ok: true }
+      })
+    }
+
+    const executor = new JobExecutor(jobsRepository, { REGISTER_IDENTITY: handler })
+    await executor.runJob(event('job-1', 'REGISTER_IDENTITY'))
+
+    expect(setStageSpy.mock.calls.map((call) => call[1])).toEqual([
+      'building-asset-lock',
+      'waiting-asset-lock-proof'
+    ])
+  })
+
+  test('completes and persists the outcome even after the popup is gone', async () => {
+    const gate = deferred()
+    const reachedWait = deferred()
+
+    const handler = {
+      validatePayload: jest.fn(() => null),
+      handle: jest.fn(async (_event: EventData, ctx?: any) => {
+        await ctx.onProgress('waiting-asset-lock-proof')
+        reachedWait.resolve()
+        // Long asset-lock wait — nothing is listening on the client side.
+        await gate.promise
+        return { identifier: 'abc' }
+      })
+    }
+
+    const executor = new JobExecutor(jobsRepository, { REGISTER_IDENTITY: handler })
+
+    // Kick off the job but do NOT await it — the popup would have posted this and
+    // could close at any moment.
+    const running = executor.runJob(event('job-1', 'REGISTER_IDENTITY'))
+
+    // Once the handler has parked on the long wait, the state is readable from
+    // storage via a brand-new repository instance (i.e. a reopened popup / a
+    // different context), not from memory.
+    await reachedWait.promise
+    const midJob = await new JobsRepository(storage).getById('job-1')
+    expect(midJob?.status).toBe(JobStatus.running)
+    expect(midJob?.stage).toBe('waiting-asset-lock-proof')
+
+    // The long wait finishes while the original caller is gone.
+    gate.resolve()
+    await running
+
+    const finalJob = await new JobsRepository(storage).getById('job-1')
+    expect(finalJob?.status).toBe(JobStatus.succeeded)
+    expect(finalJob?.result).toEqual({ identifier: 'abc' })
+  })
+
+  test('records a plain handler error as a failed job without rejecting', async () => {
+    const handler = {
+      validatePayload: jest.fn(() => null),
+      handle: jest.fn(async () => { throw new Error('platform rejected transition') })
+    }
+
+    const executor = new JobExecutor(jobsRepository, { REGISTER_IDENTITY: handler })
+    await expect(executor.runJob(event('job-1', 'REGISTER_IDENTITY'))).resolves.toBeUndefined()
+
+    const job = await jobsRepository.getById('job-1')
+    expect(job?.status).toBe(JobStatus.failed)
+    expect(job?.error).toEqual({ message: 'platform rejected transition' })
+    expect(job?.result).toBeNull()
+  })
+
+  test('preserves signedHex from a BroadcastError so the popup can re-broadcast', async () => {
+    const handler = {
+      validatePayload: jest.fn(() => null),
+      handle: jest.fn(async () => { throw new BroadcastError('Broadcast failed', 'deadbeef') })
+    }
+
+    const executor = new JobExecutor(jobsRepository, { SEND_PLATFORM_TRANSFER: handler })
+    await executor.runJob(event('job-1', 'SEND_PLATFORM_TRANSFER'))
+
+    const job = await jobsRepository.getById('job-1')
+    expect(job?.status).toBe(JobStatus.failed)
+    expect(job?.error).toEqual({ message: 'Broadcast failed', signedHex: 'deadbeef' })
+  })
+
+  test('fails the job when no handler is registered for the method', async () => {
+    const executor = new JobExecutor(jobsRepository, {})
+    await executor.runJob(event('job-1', 'UNKNOWN_METHOD'))
+
+    const job = await jobsRepository.getById('job-1')
+    expect(job?.status).toBe(JobStatus.failed)
+    expect(job?.error?.message).toBe('Could not find handler for method UNKNOWN_METHOD')
+  })
+
+  test('fails the job on invalid payload without running the handler', async () => {
+    const handler = {
+      validatePayload: jest.fn(() => 'amount is required'),
+      handle: jest.fn(async () => ({}))
+    }
+
+    const executor = new JobExecutor(jobsRepository, { SEND_PLATFORM_TRANSFER: handler })
+    await executor.runJob(event('job-1', 'SEND_PLATFORM_TRANSFER'))
+
+    expect(handler.handle).not.toHaveBeenCalled()
+    const job = await jobsRepository.getById('job-1')
+    expect(job?.status).toBe(JobStatus.failed)
+    expect(job?.error?.message).toBe('Invalid payload: amount is required')
+  })
+
+  test('marks in-flight jobs interrupted on restart, leaving terminal jobs intact', async () => {
+    await jobsRepository.create('pending-job', 'REGISTER_IDENTITY')
+
+    await jobsRepository.create('running-job', 'SHIELD_TO_POOL')
+    await jobsRepository.setStage('running-job', 'proving')
+
+    await jobsRepository.create('done-job', 'TOP_UP_IDENTITY')
+    await jobsRepository.markSucceeded('done-job', { ok: true })
+
+    const executor = new JobExecutor(jobsRepository, {})
+    await executor.reconcileInterrupted()
+
+    expect((await jobsRepository.getById('pending-job'))?.status).toBe(JobStatus.interrupted)
+    expect((await jobsRepository.getById('running-job'))?.status).toBe(JobStatus.interrupted)
+    // Terminal jobs are untouched.
+    expect((await jobsRepository.getById('done-job'))?.status).toBe(JobStatus.succeeded)
+  })
+})

--- a/test/api/private/identities/registerIdentity.spec.ts
+++ b/test/api/private/identities/registerIdentity.spec.ts
@@ -1,7 +1,7 @@
 import { PrivateKey, encrypt } from 'eciesjs'
 import hash from 'hash.js'
 import { PrivateKeyWASM } from 'dash-platform-sdk/types'
-import { RegisterIdentityHandler } from '../../../../src/content-script/api/private/identities/registerIdentity'
+import { RegisterIdentityHandler, REGISTER_IDENTITY_STAGES } from '../../../../src/content-script/api/private/identities/registerIdentity'
 import { bytesToHex, hexToBytes } from '../../../../src/utils'
 import { buildAssetLockFromFundingTx } from '../../../../src/utils/buildAssetLockFromFundingTx'
 import { waitForAssetLockProof } from '../../../../src/utils/waitForAssetLockProof'
@@ -179,7 +179,7 @@ describe('RegisterIdentityHandler', () => {
     )
   })
 
-  const handle = async (): Promise<any> => {
+  const handle = async (ctx?: { onProgress: (stage: string) => void }): Promise<any> => {
     return await handler.handle({
       context: 'dash-platform-extension',
       id: 'id',
@@ -190,7 +190,7 @@ describe('RegisterIdentityHandler', () => {
         assetLockFundingTxid,
         password
       }
-    })
+    }, ctx)
   }
 
   test('aborts the index scan on a non-not-found error instead of treating it as a free index', async () => {
@@ -346,5 +346,54 @@ describe('RegisterIdentityHandler', () => {
 
     expect(identitiesRepository.create).not.toHaveBeenCalled()
     expect(identitiesRepository.remove).not.toHaveBeenCalled()
+  })
+
+  test('reports progress stages in execution order on the happy path', async () => {
+    const stages: string[] = []
+
+    await handle({ onProgress: (stage) => { stages.push(stage) } })
+
+    expect(stages).toEqual([
+      REGISTER_IDENTITY_STAGES.preparing,
+      REGISTER_IDENTITY_STAGES.buildingAssetLock,
+      REGISTER_IDENTITY_STAGES.broadcastingAssetLock,
+      REGISTER_IDENTITY_STAGES.waitingAssetLockProof,
+      REGISTER_IDENTITY_STAGES.broadcastingStateTransition,
+      REGISTER_IDENTITY_STAGES.confirming
+    ])
+  })
+
+  test('skips the broadcastingAssetLock stage when recovering an already-broadcast asset lock', async () => {
+    assetLockFundingAddressesRepository.getByAddress.mockResolvedValueOnce({
+      address: assetLockFundingAddress,
+      encryptedPrivateKey,
+      used: false,
+      assetLockTxid
+    })
+
+    const stages: string[] = []
+
+    await handle({ onProgress: (stage) => { stages.push(stage) } })
+
+    expect(stages).toEqual([
+      REGISTER_IDENTITY_STAGES.preparing,
+      REGISTER_IDENTITY_STAGES.buildingAssetLock,
+      REGISTER_IDENTITY_STAGES.waitingAssetLockProof,
+      REGISTER_IDENTITY_STAGES.broadcastingStateTransition,
+      REGISTER_IDENTITY_STAGES.confirming
+    ])
+  })
+
+  test('skips the confirming stage when the state transition is already in chain', async () => {
+    sdk.stateTransitions.broadcast.mockRejectedValueOnce(
+      new Error('Object already exists: state transition already in chain')
+    )
+
+    const stages: string[] = []
+
+    await handle({ onProgress: (stage) => { stages.push(stage) } })
+
+    expect(stages).not.toContain(REGISTER_IDENTITY_STAGES.confirming)
+    expect(stages[stages.length - 1]).toBe(REGISTER_IDENTITY_STAGES.broadcastingStateTransition)
   })
 })

--- a/test/api/private/wallet/shieldToPool.spec.ts
+++ b/test/api/private/wallet/shieldToPool.spec.ts
@@ -1,0 +1,147 @@
+import { ShieldToPoolHandler, SHIELD_TO_POOL_STAGES } from '../../../../src/content-script/api/private/wallet/shieldToPool'
+import { buildPlatformSourceCandidates, decryptMnemonic, selectPlatformSource } from '../../../../src/utils'
+
+jest.mock('../../../../src/utils', () => {
+  const actual = jest.requireActual('../../../../src/utils')
+  return {
+    ...actual,
+    buildPlatformSourceCandidates: jest.fn(),
+    selectPlatformSource: jest.fn(),
+    decryptMnemonic: jest.fn()
+  }
+})
+
+// Keep the real pshenmic-dpp (dash-platform-sdk pulls PLATFORM_V12 etc. from it)
+// and only stub the two WASM constructors the handler builds, so no address /
+// proof WASM validation runs in the test.
+jest.mock('pshenmic-dpp', () => {
+  const actual = jest.requireActual('pshenmic-dpp')
+  return {
+    ...actual,
+    InputAddressWASM: jest.fn().mockImplementation((platformAddress, nonce, balance) => ({ platformAddress, nonce, balance })),
+    AddressFundsFeeStrategyStepWASM: {
+      ...actual.AddressFundsFeeStrategyStepWASM,
+      DeductFromInput: jest.fn((index) => ({ deductFromInput: index }))
+    }
+  }
+})
+
+const buildPlatformSourceCandidatesMock = buildPlatformSourceCandidates as jest.MockedFunction<typeof buildPlatformSourceCandidates>
+const selectPlatformSourceMock = selectPlatformSource as jest.MockedFunction<typeof selectPlatformSource>
+const decryptMnemonicMock = decryptMnemonic as jest.MockedFunction<typeof decryptMnemonic>
+
+describe('ShieldToPoolHandler', () => {
+  const password = 'test'
+  const source = {
+    index: 0,
+    platformAddress: 'yShieldSource',
+    nonce: 3,
+    balanceCredits: 100_000_000n
+  }
+
+  let order: string[]
+  let walletRepository: any
+  let sdk: any
+  let handler: ShieldToPoolHandler
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    order = []
+
+    walletRepository = {
+      getCurrent: jest.fn(async () => ({
+        walletId: 'wallet1',
+        type: 'seedphrase',
+        network: 'testnet',
+        label: null,
+        encryptedMnemonic: 'encryptedMnemonic',
+        seedHash: 'seedHash',
+        currentIdentity: null
+      })),
+      getPlatformAccountXpub: jest.fn(async () => 'xpub'),
+      getPlatformAddressCount: jest.fn(async () => 1)
+    }
+
+    sdk = {
+      keyPair: {
+        mnemonicToSeed: jest.fn(() => new Uint8Array([1, 2, 3])),
+        derivePlatformAddressPrivateKey: jest.fn(async () => 'privateKey'),
+        deriveShieldedAddress: jest.fn(() => 'shieldedRecipient'),
+        deriveShieldedOutgoingViewingKey: jest.fn(() => 'ovk')
+      },
+      shielded: {
+        createStateTransition: jest.fn(async () => {
+          order.push('prove')
+          return { hash: jest.fn(() => 'stHash') }
+        })
+      },
+      stateTransitions: {
+        broadcast: jest.fn(async () => {
+          order.push('broadcast')
+        }),
+        waitForStateTransitionResult: jest.fn(async () => {
+          order.push('wait')
+        })
+      }
+    }
+
+    buildPlatformSourceCandidatesMock.mockResolvedValue([] as any)
+    selectPlatformSourceMock.mockReturnValue(source as any)
+    decryptMnemonicMock.mockReturnValue('mnemonic words')
+
+    handler = new ShieldToPoolHandler(walletRepository, sdk)
+  })
+
+  const handle = async (ctx?: { onProgress: (stage: string) => void }): Promise<any> => {
+    return await handler.handle({
+      context: 'dash-platform-extension',
+      id: 'id',
+      method: 'SHIELD_TO_POOL',
+      type: 'request',
+      payload: { amountCredits: '1000', password }
+    }, ctx)
+  }
+
+  test('shields with full happy-path flow', async () => {
+    const result = await handle()
+
+    expect(result).toEqual({
+      stHash: 'stHash',
+      amountCredits: '1000',
+      fromAddress: source.platformAddress
+    })
+    expect(sdk.shielded.createStateTransition).toHaveBeenCalled()
+    expect(sdk.stateTransitions.broadcast).toHaveBeenCalled()
+    expect(sdk.stateTransitions.waitForStateTransitionResult).toHaveBeenCalled()
+    expect(order).toEqual(['prove', 'broadcast', 'wait'])
+  })
+
+  test('reports progress stages in execution order, with proving before broadcast', async () => {
+    const stages: string[] = []
+
+    await handle({ onProgress: (stage) => { stages.push(stage) } })
+
+    expect(stages).toEqual([
+      SHIELD_TO_POOL_STAGES.preparing,
+      SHIELD_TO_POOL_STAGES.proving,
+      SHIELD_TO_POOL_STAGES.broadcasting,
+      SHIELD_TO_POOL_STAGES.confirming
+    ])
+  })
+
+  test('works without a progress context (in-popup path)', async () => {
+    await expect(handle()).resolves.toBeDefined()
+  })
+
+  test('does not reach the proving stage when no wallet is chosen', async () => {
+    walletRepository.getCurrent.mockResolvedValueOnce(null)
+    const stages: string[] = []
+
+    await expect(handle({ onProgress: (stage) => { stages.push(stage) } }))
+      .rejects.toThrow('No wallet is chosen')
+
+    expect(stages).toEqual([SHIELD_TO_POOL_STAGES.preparing])
+    expect(sdk.shielded.createStateTransition).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Why

The extension has no background service worker: long async operations (identity registration asset-lock waits, Halo2 shielded proving, state-transition confirmation) run inside the ephemeral popup and die when it closes or loses focus.

This PR lands the **context-agnostic core** of a service-worker + offscreen job model, fully unit-tested without a browser. No manifest/webpack/runtime wiring yet — that comes next and needs manual browser verification.

## Layers (one commit each)

1. **Job persistence** — `JobStatus` enum, `JobStoreSchema`, `JobsRepository` (pure CRUD, scoped `jobs_${network}_${walletId}`, preserves `error.signedHex` for re-broadcast).
2. **Handler contract** — `LongRunningHandler` extends `APIHandler` with an optional `onProgress` progress context. `registerIdentity` (IO-wait stages) and `shieldToPool` (Halo2 `proving` stage) wired as reference handlers. `onProgress` is strictly optional, so the current in-popup path is unchanged (backward compatible).
3. **Executor** — `JobExecutor`: creates a job, runs the handler streaming stages into `JobsRepository`, maps success/failure to storage, never rejects. Plus `reconcileInterrupted()` for SW/offscreen restart.

## Key invariant proven by tests

`JobExecutor.spec` includes a "popup is gone" test: a job runs unawaited, its `running`+`stage` state is read back through a **fresh** `JobsRepository` instance (from storage, not memory), and it reaches `succeeded` after the long wait — i.e. the operation survives the popup closing.

## Tests

- New/changed specs: `JobsRepository` (12), `registerIdentity` (13, incl. stage order + backward compat), `shieldToPool` (4), `JobExecutor` (8) — **37 passing**.
- `ts-standard` clean on all changed files.

## Not in this PR (next steps, manual browser verification)

- Thin adapters: `background/index.ts` (SW) + `offscreen/index.ts`.
- `manifest.json` (`background.service_worker`, `offscreen`/`alarms` permissions) + webpack entries.
- `PrivateAPIClient` job-methods over `sendMessage` + `chrome.storage.onChanged` (hybrid: fast methods keep the dispatch path).
- Phase 0 spike: dpp/Halo2 WASM in an offscreen document.

Do not merge yet.