### PR TITLE
feat: per-address breakdown for shielded balance

### DIFF
--- a/src/content-script/api/private/wallet/getShieldedBalance.ts
+++ b/src/content-script/api/private/wallet/getShieldedBalance.ts
@@ -2,7 +2,8 @@ import { EventData } from '../../../../types/EventData'
 import { APIHandler } from '../../APIHandler'
 import { WalletRepository } from '../../../repository/WalletRepository'
 import { DashPlatformSDK } from 'dash-platform-sdk'
-import { decryptMnemonic, fetchAllShieldedNotes, sumUnspentShieldedValue } from '../../../../utils'
+import { decryptMnemonic, deriveShieldedAddresses, fetchAllShieldedNotes, sumUnspentShieldedValue } from '../../../../utils'
+import { SHIELDED_ADDRESS_DEFAULT_COUNT } from '../../../../constants'
 import { GetShieldedBalancePayload } from '../../../../types/messages/payloads/GetShieldedBalancePayload'
 import { GetShieldedBalanceResponse } from '../../../../types/messages/response/GetShieldedBalanceResponse'
 
@@ -46,9 +47,25 @@ export class GetShieldedBalanceHandler implements APIHandler {
       ? await this.sdk.shielded.getShieldedNullifiers(nullifiers)
       : []
 
-    const { balance, spendableNotes } = sumUnspentShieldedValue(recovered, allNotes, statuses)
+    // Map our known diversified addresses to their derivation index so the
+    // per-address breakdown can label them; notes to an address outside this
+    // window still count, with diversifierIndex null.
+    const derived = deriveShieldedAddresses(wallet, payload.password, account, SHIELDED_ADDRESS_DEFAULT_COUNT, this.sdk)
+    const diversifierIndexByAddress = new Map(derived.map(entry => [entry.address, entry.diversifierIndex]))
 
-    return { balance: balance.toString(), spendableNotes, totalNotes: allNotes.length }
+    const { balance, spendableNotes, byAddress } = sumUnspentShieldedValue(recovered, allNotes, statuses, wallet.network, diversifierIndexByAddress)
+
+    return {
+      balance: balance.toString(),
+      spendableNotes,
+      totalNotes: allNotes.length,
+      byAddress: byAddress.map(entry => ({
+        address: entry.address,
+        diversifierIndex: entry.diversifierIndex,
+        balance: entry.balance.toString(),
+        spendableNotes: entry.spendableNotes
+      }))
+    }
   }
 
   validatePayload (payload: GetShieldedBalancePayload): string | null {

--- a/src/types/messages/response/GetShieldedBalanceResponse.ts
+++ b/src/types/messages/response/GetShieldedBalanceResponse.ts
@@ -1,7 +1,22 @@
+export interface ShieldedAddressBalanceEntry {
+  // Diversified Orchard address (bech32m) that received the notes.
+  address: string
+  // Our derivation index for this address, or null when it falls outside the
+  // derived window (balance is still counted, only the index is unknown).
+  diversifierIndex: number | null
+  // balance crosses the messaging boundary as a string (bigint does not
+  // serialize); parse with BigInt(...) on the consumer side.
+  balance: string
+  spendableNotes: number
+}
+
 export interface GetShieldedBalanceResponse {
   // balance crosses the messaging boundary as a string (bigint does not
   // serialize); parse with BigInt(...) on the consumer side.
   balance: string
   spendableNotes: number
   totalNotes: number
+  // Per-address breakdown of the unspent balance above; the address balances
+  // sum to `balance` and the spendableNotes sum to `spendableNotes`.
+  byAddress: ShieldedAddressBalanceEntry[]
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -353,15 +353,36 @@ export const fetchAllShieldedNotes = async (sdk: DashPlatformSDK): Promise<Shiel
   return notes
 }
 
-// Sums the value of recovered notes that are not yet spent. Spent status is
-// matched by nullifier hex (not array order — getShieldedNullifiers does not
-// guarantee response order), and each recovered note's nullifier is taken from
-// its leaf in `allNotes` via the global `index`.
-export const sumUnspentShieldedValue = (recovered: RecoveredNoteWASM[], allNotes: ShieldedEncryptedNote[], statuses: ShieldedNullifierStatus[]): { balance: bigint, spendableNotes: number } => {
+export interface ShieldedAddressBalance {
+  // Diversified Orchard address (bech32m) that received the notes.
+  address: string
+  // Our derivation index for this address, or null when it falls outside the
+  // derived window (the balance is still counted, only the index is unknown).
+  diversifierIndex: number | null
+  balance: bigint
+  spendableNotes: number
+}
+
+// Sums the value of recovered notes that are not yet spent, both in aggregate
+// and grouped by the diversified Orchard address that received each note
+// (`note.address` from the trial-decrypted plaintext). Spent status is matched
+// by nullifier hex (not array order — getShieldedNullifiers does not guarantee
+// response order), and each recovered note's nullifier is taken from its leaf in
+// `allNotes` via the global `index`. `diversifierIndexByAddress` attributes our
+// known address indices; a note to an address outside that map gets
+// diversifierIndex null.
+export const sumUnspentShieldedValue = (
+  recovered: RecoveredNoteWASM[],
+  allNotes: ShieldedEncryptedNote[],
+  statuses: ShieldedNullifierStatus[],
+  network: NetworkType,
+  diversifierIndexByAddress: Map<string, number> = new Map()
+): { balance: bigint, spendableNotes: number, byAddress: ShieldedAddressBalance[] } => {
   const spent = new Set(statuses.filter(status => status.isSpent).map(status => bytesToHex(status.nullifier)))
 
   let balance = 0n
   let spendableNotes = 0
+  const buckets = new Map<string, { balance: bigint, spendableNotes: number }>()
 
   for (const recoveredNote of recovered) {
     const encryptedNote = allNotes[recoveredNote.index]
@@ -370,11 +391,25 @@ export const sumUnspentShieldedValue = (recovered: RecoveredNoteWASM[], allNotes
       continue
     }
 
-    balance += recoveredNote.note.value
+    const value = recoveredNote.note.value
+    balance += value
     spendableNotes += 1
+
+    const address = recoveredNote.note.address.toBech32m(network)
+    const bucket = buckets.get(address) ?? { balance: 0n, spendableNotes: 0 }
+    bucket.balance += value
+    bucket.spendableNotes += 1
+    buckets.set(address, bucket)
   }
 
-  return { balance, spendableNotes }
+  const byAddress: ShieldedAddressBalance[] = Array.from(buckets.entries()).map(([address, bucket]) => ({
+    address,
+    diversifierIndex: diversifierIndexByAddress.get(address) ?? null,
+    balance: bucket.balance,
+    spendableNotes: bucket.spendableNotes
+  }))
+
+  return { balance, spendableNotes, byAddress }
 }
 
 export interface ShieldedSpendInputs {

--- a/test/api/private/wallet/getShieldedBalance.spec.ts
+++ b/test/api/private/wallet/getShieldedBalance.spec.ts
@@ -1,0 +1,102 @@
+import { GetShieldedBalanceHandler } from '../../../../src/content-script/api/private/wallet/getShieldedBalance'
+import { decryptMnemonic, deriveShieldedAddresses, fetchAllShieldedNotes } from '../../../../src/utils'
+
+// Mock the network / derivation primitives but keep sumUnspentShieldedValue real,
+// so this exercises the handler wiring plus the actual per-address grouping.
+jest.mock('../../../../src/utils', () => {
+  const actual = jest.requireActual('../../../../src/utils')
+  return {
+    ...actual,
+    decryptMnemonic: jest.fn(),
+    fetchAllShieldedNotes: jest.fn(),
+    deriveShieldedAddresses: jest.fn()
+  }
+})
+
+const decryptMnemonicMock = decryptMnemonic as jest.MockedFunction<typeof decryptMnemonic>
+const fetchAllShieldedNotesMock = fetchAllShieldedNotes as jest.MockedFunction<typeof fetchAllShieldedNotes>
+const deriveShieldedAddressesMock = deriveShieldedAddresses as jest.MockedFunction<typeof deriveShieldedAddresses>
+
+const ADDR_0 = 'orchardAddress0'
+const ADDR_OUT = 'orchardAddressOutOfWindow'
+
+const recoveredNote = (index: number, value: bigint, address: string): any => ({
+  index,
+  note: { value, address: { toBech32m: () => address } }
+})
+
+describe('GetShieldedBalanceHandler', () => {
+  let walletRepository: any
+  let sdk: any
+  let handler: GetShieldedBalanceHandler
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    walletRepository = {
+      getCurrent: jest.fn(async () => ({
+        walletId: 'wallet1',
+        type: 'seedphrase',
+        network: 'testnet',
+        label: null,
+        encryptedMnemonic: 'encryptedMnemonic',
+        seedHash: 'seedHash',
+        currentIdentity: null
+      }))
+    }
+
+    sdk = {
+      keyPair: {
+        mnemonicToSeed: jest.fn(() => new Uint8Array([1, 2, 3]))
+      },
+      shielded: {
+        recoverNotes: jest.fn(() => [
+          recoveredNote(0, 100n, ADDR_0),
+          recoveredNote(1, 40n, ADDR_0),
+          recoveredNote(2, 25n, ADDR_OUT)
+        ]),
+        getShieldedNullifiers: jest.fn(async () => [])
+      }
+    }
+
+    decryptMnemonicMock.mockReturnValue('mnemonic words')
+    fetchAllShieldedNotesMock.mockResolvedValue([
+      { nullifier: Uint8Array.from([1]) },
+      { nullifier: Uint8Array.from([2]) },
+      { nullifier: Uint8Array.from([3]) }
+    ] as any)
+    deriveShieldedAddressesMock.mockReturnValue([
+      { address: ADDR_0, derivationPath: "m/32'/1'/0'", diversifierIndex: 0 }
+    ])
+
+    handler = new GetShieldedBalanceHandler(walletRepository, sdk)
+  })
+
+  const handle = async (): Promise<any> => {
+    return await handler.handle({
+      context: 'dash-platform-extension',
+      id: 'id',
+      method: 'GET_SHIELDED_BALANCE',
+      type: 'request',
+      payload: { password: 'test' }
+    })
+  }
+
+  it('returns the aggregate balance plus a per-address breakdown', async () => {
+    const result = await handle()
+
+    expect(result.balance).toBe('165')
+    expect(result.spendableNotes).toBe(3)
+    expect(result.totalNotes).toBe(3)
+
+    const byAddr = Object.fromEntries(result.byAddress.map((entry: any) => [entry.address, entry]))
+    expect(byAddr[ADDR_0]).toEqual({ address: ADDR_0, diversifierIndex: 0, balance: '140', spendableNotes: 2 })
+    expect(byAddr[ADDR_OUT]).toEqual({ address: ADDR_OUT, diversifierIndex: null, balance: '25', spendableNotes: 1 })
+  })
+
+  it('throws when no wallet is chosen', async () => {
+    walletRepository.getCurrent.mockResolvedValueOnce(null)
+
+    await expect(handle()).rejects.toThrow('No wallet is chosen')
+  })
+})

--- a/test/utils/sumUnspentShieldedValue.spec.ts
+++ b/test/utils/sumUnspentShieldedValue.spec.ts
@@ -1,0 +1,81 @@
+import { sumUnspentShieldedValue } from '../../src/utils'
+
+// Minimal stand-ins for the WASM note shapes the function reads:
+// recoveredNote.index, recoveredNote.note.value, recoveredNote.note.address.toBech32m().
+const recoveredNote = (index: number, value: bigint, address: string): any => ({
+  index,
+  note: { value, address: { toBech32m: () => address } }
+})
+
+const leaf = (nullifier: number[]): any => ({ nullifier: Uint8Array.from(nullifier) })
+const status = (nullifier: number[], isSpent: boolean): any => ({ nullifier: Uint8Array.from(nullifier), isSpent })
+
+const ADDR_1 = 'orchardAddress1'
+const ADDR_2 = 'orchardAddress2'
+
+describe('sumUnspentShieldedValue', () => {
+  it('returns a zero balance and empty breakdown for no notes', () => {
+    const result = sumUnspentShieldedValue([], [], [], 'testnet')
+
+    expect(result).toEqual({ balance: 0n, spendableNotes: 0, byAddress: [] })
+  })
+
+  it('groups unspent notes by receiving address and the aggregate equals the bucket sum', () => {
+    const recovered = [
+      recoveredNote(0, 100n, ADDR_1),
+      recoveredNote(1, 50n, ADDR_1),
+      recoveredNote(2, 30n, ADDR_2)
+    ]
+    const allNotes = [leaf([1]), leaf([2]), leaf([3])]
+
+    const { balance, spendableNotes, byAddress } = sumUnspentShieldedValue(recovered, allNotes, [], 'testnet')
+
+    expect(balance).toBe(180n)
+    expect(spendableNotes).toBe(3)
+
+    const byAddr = Object.fromEntries(byAddress.map((entry) => [entry.address, entry]))
+    expect(byAddr[ADDR_1]).toEqual({ address: ADDR_1, diversifierIndex: null, balance: 150n, spendableNotes: 2 })
+    expect(byAddr[ADDR_2]).toEqual({ address: ADDR_2, diversifierIndex: null, balance: 30n, spendableNotes: 1 })
+    expect(byAddress.reduce((sum, entry) => sum + entry.balance, 0n)).toBe(balance)
+  })
+
+  it('excludes spent notes from both the aggregate and the per-address bucket', () => {
+    const recovered = [
+      recoveredNote(0, 100n, ADDR_1),
+      recoveredNote(1, 50n, ADDR_1)
+    ]
+    const allNotes = [leaf([1]), leaf([2])]
+    const statuses = [status([2], true)]
+
+    const { balance, spendableNotes, byAddress } = sumUnspentShieldedValue(recovered, allNotes, statuses, 'testnet')
+
+    expect(balance).toBe(100n)
+    expect(spendableNotes).toBe(1)
+    expect(byAddress).toEqual([{ address: ADDR_1, diversifierIndex: null, balance: 100n, spendableNotes: 1 }])
+  })
+
+  it('skips a recovered note whose leaf is missing from allNotes', () => {
+    const recovered = [recoveredNote(5, 100n, ADDR_1)]
+
+    const { balance, spendableNotes, byAddress } = sumUnspentShieldedValue(recovered, [], [], 'testnet')
+
+    expect(balance).toBe(0n)
+    expect(spendableNotes).toBe(0)
+    expect(byAddress).toEqual([])
+  })
+
+  it('attaches the derivation index when the address is known, null otherwise', () => {
+    const recovered = [
+      recoveredNote(0, 100n, ADDR_1),
+      recoveredNote(1, 30n, ADDR_2)
+    ]
+    const allNotes = [leaf([1]), leaf([2])]
+    const diversifierIndexByAddress = new Map([[ADDR_1, 3]])
+
+    const { byAddress } = sumUnspentShieldedValue(recovered, allNotes, [], 'testnet', diversifierIndexByAddress)
+
+    const byAddr = Object.fromEntries(byAddress.map((entry) => [entry.address, entry.diversifierIndex]))
+    expect(byAddr[ADDR_1]).toBe(3)
+    expect(byAddr[ADDR_2]).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Adds a per-address breakdown of the shielded (Orchard) balance to `GET_SHIELDED_BALANCE`. Previously only the account-level aggregate was returned; now the response also shows how much sits on each diversified address.

## How

Each recovered note already carries its receiving address (`RecoveredNoteWASM.note.address`), so the breakdown is computed in the same pass, with no extra network calls.

- `sumUnspentShieldedValue` (service primitive) now, in addition to the aggregate, groups unspent notes by `note.address` into `byAddress`; it takes `network` and an optional `address -> diversifierIndex` map.
- `GetShieldedBalanceResponse` is extended additively with `byAddress` (the aggregate `balance`/`spendableNotes`/`totalNotes` fields are preserved — backward compatible).
- The handler builds the map of our known addresses via `deriveShieldedAddresses` (window = `SHIELDED_ADDRESS_DEFAULT_COUNT`); notes to an address outside that window are still counted, with `diversifierIndex: null` (no balance is lost).

## Tests

- `test/utils/sumUnspentShieldedValue.spec.ts` — grouping, aggregate equals the bucket sum, spent notes excluded, notes with a missing leaf skipped, index/null attribution.
- `test/api/private/wallet/getShieldedBalance.spec.ts` — handler integration with the real grouping primitive.

All new tests pass, lint is clean.
