### PR TITLE
feat: shielded transfer from specific source addresses

### DIFF
--- a/src/content-script/api/private/wallet/sendShieldedTransfer.ts
+++ b/src/content-script/api/private/wallet/sendShieldedTransfer.ts
@@ -36,7 +36,7 @@ export class SendShieldedTransferHandler implements APIHandler {
     const amountCredits = BigInt(payload.amountCredits)
     const seed = this.sdk.keyPair.mnemonicToSeed(decryptMnemonic(wallet, payload.password))
 
-    const { spends, anchor, changeAddress, coinType } = await prepareShieldedSpend(this.sdk, seed, wallet.network, account, amountCredits + SHIELDED_SPEND_FEE_CREDITS)
+    const { spends, anchor, changeAddress, coinType } = await prepareShieldedSpend(this.sdk, seed, wallet.network, account, amountCredits + SHIELDED_SPEND_FEE_CREDITS, payload.fromAddresses)
 
     console.time('[shielded] transfer: build + prove')
     const stateTransition = await this.sdk.shielded.createStateTransition('shieldedTransfer', {
@@ -75,6 +75,14 @@ export class SendShieldedTransferHandler implements APIHandler {
     }
     if (payload.account != null && (!Number.isInteger(payload.account) || payload.account < 0)) {
       return 'Account must be a non-negative integer'
+    }
+    if (payload.fromAddresses != null) {
+      if (!Array.isArray(payload.fromAddresses) || payload.fromAddresses.length === 0) {
+        return 'fromAddresses must be a non-empty array of addresses'
+      }
+      if (!payload.fromAddresses.every(address => typeof address === 'string' && address.length > 0)) {
+        return 'fromAddresses must contain only non-empty address strings'
+      }
     }
     if (payload.memo != null && typeof payload.memo !== 'string') {
       return 'memo must be a string'

--- a/src/types/PrivateAPIClient.ts
+++ b/src/types/PrivateAPIClient.ts
@@ -498,8 +498,8 @@ export class PrivateAPIClient {
     return await this._rpcCall(MessagingMethods.SHIELD_TO_POOL, payload, SHIELDED_PROVE_TIMEOUT)
   }
 
-  async sendShieldedTransfer (toShieldedAddress: string, amountCredits: string, password: string, account?: number, memo?: string): Promise<SendShieldedTransferResponse> {
-    const payload: SendShieldedTransferPayload = { toShieldedAddress, amountCredits, password, account, memo }
+  async sendShieldedTransfer (toShieldedAddress: string, amountCredits: string, password: string, account?: number, memo?: string, fromAddresses?: string[]): Promise<SendShieldedTransferResponse> {
+    const payload: SendShieldedTransferPayload = { toShieldedAddress, amountCredits, password, account, fromAddresses, memo }
 
     return await this._rpcCall(MessagingMethods.SEND_SHIELDED_TRANSFER, payload, SHIELDED_PROVE_TIMEOUT)
   }

--- a/src/types/messages/payloads/SendShieldedTransferPayload.ts
+++ b/src/types/messages/payloads/SendShieldedTransferPayload.ts
@@ -5,6 +5,9 @@ export interface SendShieldedTransferPayload {
   amountCredits: string
   password: string
   account?: number
+  // optional source shielded addresses (bech32m) to spend from; when omitted the
+  // spend may draw from any of the account's notes
+  fromAddresses?: string[]
   // optional UTF-8 memo carried inside the shielded transfer
   memo?: string
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -384,6 +384,15 @@ export interface ShieldedSpendInputs {
   coinType: number
 }
 
+// Narrows recovered notes to those received on one of `fromAddresses` (bech32m),
+// so a spend can draw only from specific source shielded addresses instead of the
+// whole account. Notes are keyed by their receiving address (`note.address`).
+export const filterRecoveredNotesByAddress = (notes: RecoveredNoteWASM[], fromAddresses: string[], network: NetworkType): RecoveredNoteWASM[] => {
+  const wanted = new Set(fromAddresses)
+
+  return notes.filter(recoveredNote => wanted.has(recoveredNote.note.address.toBech32m(network)))
+}
+
 // Selects the fewest notes (largest first) whose combined value covers
 // `requiredCredits`. Minimizing the note count keeps the Orchard bundle — one
 // action per note — under Platform's state-transition size limit. Throws if the
@@ -417,7 +426,9 @@ const selectShieldedNotes = (spendable: RecoveredNoteWASM[], requiredCredits: bi
 // (amount + fee), witnesses just those against the commitment tree, and derives
 // the change address. The Halo2 builder is not touched here — proving happens
 // inside the createStateTransition call the handler makes with these inputs.
-export const prepareShieldedSpend = async (sdk: DashPlatformSDK, seed: Uint8Array, network: NetworkType, account: number, requiredCredits: bigint): Promise<ShieldedSpendInputs> => {
+// `fromAddresses` (optional) restricts the spend to notes on those source
+// shielded addresses; when omitted, the whole account's notes are eligible.
+export const prepareShieldedSpend = async (sdk: DashPlatformSDK, seed: Uint8Array, network: NetworkType, account: number, requiredCredits: bigint, fromAddresses?: string[]): Promise<ShieldedSpendInputs> => {
   console.time('[shielded] sync notes')
   const allNotes = await fetchAllShieldedNotes(sdk)
   console.timeEnd('[shielded] sync notes')
@@ -446,8 +457,17 @@ export const prepareShieldedSpend = async (sdk: DashPlatformSDK, seed: Uint8Arra
     throw new Error('No unspent shielded notes available to spend')
   }
 
-  const selected = selectShieldedNotes(unspent, requiredCredits)
-  console.log(`[shielded] selected ${selected.length}/${unspent.length} notes; witnessing against the tree…`)
+  // Optionally restrict the spend to notes on specific source addresses.
+  const scoped = fromAddresses != null && fromAddresses.length > 0
+    ? filterRecoveredNotesByAddress(unspent, fromAddresses, network)
+    : unspent
+
+  if (scoped.length === 0) {
+    throw new Error('No unspent shielded notes on the selected source address(es)')
+  }
+
+  const selected = selectShieldedNotes(scoped, requiredCredits)
+  console.log(`[shielded] selected ${selected.length}/${scoped.length} notes; witnessing against the tree…`)
 
   console.time('[shielded] build spendable notes')
   const { spends, anchor } = sdk.shielded.buildSpendableNotes(allNotes, selected)

--- a/test/api/private/wallet/sendShieldedTransfer.spec.ts
+++ b/test/api/private/wallet/sendShieldedTransfer.spec.ts
@@ -1,0 +1,133 @@
+import { SendShieldedTransferHandler } from '../../../../src/content-script/api/private/wallet/sendShieldedTransfer'
+import { decryptMnemonic, prepareShieldedSpend } from '../../../../src/utils'
+import { SHIELDED_SPEND_FEE_CREDITS } from '../../../../src/constants'
+
+jest.mock('../../../../src/utils', () => {
+  const actual = jest.requireActual('../../../../src/utils')
+  return {
+    ...actual,
+    decryptMnemonic: jest.fn(),
+    prepareShieldedSpend: jest.fn()
+  }
+})
+
+// Keep the real pshenmic-dpp (dash-platform-sdk needs PLATFORM_V12 etc.) and only
+// stub the address parser the handler calls.
+jest.mock('pshenmic-dpp', () => {
+  const actual = jest.requireActual('pshenmic-dpp')
+  return {
+    ...actual,
+    OrchardAddressWASM: { ...actual.OrchardAddressWASM, fromBech32m: jest.fn((addr) => ({ addr })) }
+  }
+})
+
+const decryptMnemonicMock = decryptMnemonic as jest.MockedFunction<typeof decryptMnemonic>
+const prepareShieldedSpendMock = prepareShieldedSpend as jest.MockedFunction<typeof prepareShieldedSpend>
+
+const TO_ADDRESS = 'orchardRecipient'
+const SOURCE_ADDRESS = 'orchardSource0'
+
+describe('SendShieldedTransferHandler', () => {
+  let walletRepository: any
+  let sdk: any
+  let handler: SendShieldedTransferHandler
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    walletRepository = {
+      getCurrent: jest.fn(async () => ({
+        walletId: 'wallet1',
+        type: 'seedphrase',
+        network: 'testnet',
+        label: null,
+        encryptedMnemonic: 'encryptedMnemonic',
+        seedHash: 'seedHash',
+        currentIdentity: null
+      }))
+    }
+
+    sdk = {
+      keyPair: { mnemonicToSeed: jest.fn(() => new Uint8Array([1, 2, 3])) },
+      shielded: { createStateTransition: jest.fn(async () => ({ hash: jest.fn(() => 'stHash') })) },
+      stateTransitions: {
+        broadcast: jest.fn(async () => {}),
+        waitForStateTransitionResult: jest.fn(async () => {})
+      }
+    }
+
+    decryptMnemonicMock.mockReturnValue('mnemonic words')
+    prepareShieldedSpendMock.mockResolvedValue({
+      spends: [],
+      anchor: new Uint8Array([9]),
+      changeAddress: {} as any,
+      coinType: 1
+    })
+
+    handler = new SendShieldedTransferHandler(walletRepository, sdk)
+  })
+
+  const handle = async (payload: any): Promise<any> => {
+    return await handler.handle({
+      context: 'dash-platform-extension',
+      id: 'id',
+      method: 'SEND_SHIELDED_TRANSFER',
+      type: 'request',
+      payload
+    })
+  }
+
+  it('passes the requested source addresses through to prepareShieldedSpend', async () => {
+    const result = await handle({
+      toShieldedAddress: TO_ADDRESS,
+      amountCredits: '1000',
+      password: 'test',
+      fromAddresses: [SOURCE_ADDRESS]
+    })
+
+    expect(result).toEqual({ stHash: 'stHash', amountCredits: '1000', toShieldedAddress: TO_ADDRESS })
+    expect(prepareShieldedSpendMock).toHaveBeenCalledWith(
+      sdk,
+      expect.any(Uint8Array),
+      'testnet',
+      0,
+      1000n + SHIELDED_SPEND_FEE_CREDITS,
+      [SOURCE_ADDRESS]
+    )
+  })
+
+  it('passes undefined source addresses when none are requested (whole account)', async () => {
+    await handle({ toShieldedAddress: TO_ADDRESS, amountCredits: '1000', password: 'test' })
+
+    expect(prepareShieldedSpendMock).toHaveBeenCalledWith(
+      sdk,
+      expect.any(Uint8Array),
+      'testnet',
+      0,
+      1000n + SHIELDED_SPEND_FEE_CREDITS,
+      undefined
+    )
+  })
+
+  describe('validatePayload', () => {
+    const base = { toShieldedAddress: TO_ADDRESS, amountCredits: '1000', password: 'test' }
+
+    it('accepts a valid fromAddresses array', () => {
+      expect(handler.validatePayload({ ...base, fromAddresses: [SOURCE_ADDRESS] })).toBeNull()
+    })
+
+    it('accepts an absent fromAddresses', () => {
+      expect(handler.validatePayload(base as any)).toBeNull()
+    })
+
+    it('rejects an empty fromAddresses array', () => {
+      expect(handler.validatePayload({ ...base, fromAddresses: [] }))
+        .toBe('fromAddresses must be a non-empty array of addresses')
+    })
+
+    it('rejects non-string entries in fromAddresses', () => {
+      expect(handler.validatePayload({ ...base, fromAddresses: [SOURCE_ADDRESS, ''] }))
+        .toBe('fromAddresses must contain only non-empty address strings')
+    })
+  })
+})

--- a/test/utils/filterRecoveredNotesByAddress.spec.ts
+++ b/test/utils/filterRecoveredNotesByAddress.spec.ts
@@ -1,0 +1,37 @@
+import { filterRecoveredNotesByAddress } from '../../src/utils'
+
+// Stand-in for RecoveredNoteWASM: only note.address.toBech32m() is read.
+const recoveredNote = (address: string): any => ({
+  note: { address: { toBech32m: () => address } }
+})
+
+const ADDR_A = 'orchardAddressA'
+const ADDR_B = 'orchardAddressB'
+const ADDR_C = 'orchardAddressC'
+
+describe('filterRecoveredNotesByAddress', () => {
+  const notes = [recoveredNote(ADDR_A), recoveredNote(ADDR_B), recoveredNote(ADDR_A), recoveredNote(ADDR_C)]
+
+  const addressesOf = (result: any[]): string[] => result.map((note) => note.note.address.toBech32m())
+
+  it('keeps only notes received on one of the requested addresses', () => {
+    const result = filterRecoveredNotesByAddress(notes, [ADDR_A], 'testnet')
+
+    expect(result).toHaveLength(2)
+    expect(addressesOf(result)).toEqual([ADDR_A, ADDR_A])
+  })
+
+  it('supports multiple source addresses', () => {
+    const result = filterRecoveredNotesByAddress(notes, [ADDR_A, ADDR_C], 'testnet')
+
+    expect(addressesOf(result)).toEqual([ADDR_A, ADDR_A, ADDR_C])
+  })
+
+  it('returns an empty array when no note matches', () => {
+    expect(filterRecoveredNotesByAddress(notes, ['orchardUnknown'], 'testnet')).toEqual([])
+  })
+
+  it('returns an empty array for an empty address list', () => {
+    expect(filterRecoveredNotesByAddress(notes, [], 'testnet')).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Lets a shielded (pool → pool) transfer spend from **specific source shielded addresses** instead of always picking notes across the whole account at the util's discretion.

`SEND_SHIELDED_TRANSFER` now accepts an optional `fromAddresses: string[]`. When provided, only notes received on those diversified addresses are eligible for the spend; when omitted, behaviour is unchanged (any of the account's notes). Pairs with the per-address shielded balance breakdown — the UI can let the user pick which address(es) to spend from.

Notes are addressable by their receiving address (`RecoveredNoteWASM.note.address`); there is no client-visible per-note id, so the selector is address-based.

## How

- New pure primitive `filterRecoveredNotesByAddress(notes, fromAddresses, network)` narrows recovered notes to the requested addresses.
- `prepareShieldedSpend` takes an optional `fromAddresses` argument and applies the filter after dropping spent notes, before note selection. If none of the unspent notes are on the requested addresses it throws a clear error.
- `SendShieldedTransferPayload`, the handler (with `validatePayload` checks) and the `PrivateAPIClient.sendShieldedTransfer` client method are extended with the optional `fromAddresses`.

Backward compatible: omitting `fromAddresses` keeps the previous whole-account behaviour.

## Tests

- `test/utils/filterRecoveredNotesByAddress.spec.ts` — single/multiple source addresses, no match, empty list.
- `test/api/private/wallet/sendShieldedTransfer.spec.ts` — `fromAddresses` passthrough to `prepareShieldedSpend`, undefined when omitted, and payload validation.

All new tests pass, lint is clean.

## Note

Only the transfer path is wired here, as requested. `unshieldToAddress` and `withdrawShieldedToCore` share `prepareShieldedSpend`, so the same optional `fromAddresses` can be threaded through them the same way if wanted.
